### PR TITLE
11.1.3.1c Benennung einheitlich auf Buchstabe c

### DIFF
--- a/Prüfschritte/de/11.1.3.1c Zuordnung von Tabellenzellen.adoc
+++ b/Prüfschritte/de/11.1.3.1c Zuordnung von Tabellenzellen.adoc
@@ -1,4 +1,4 @@
-= Prüfschritt 1.3.1f Zuordnung von Tabellenzellen
+= Prüfschritt 1.3.1c Zuordnung von Tabellenzellen
 include::include/author.adoc[]
 include::include/attributes.adoc[]
 


### PR DESCRIPTION
Benennung Prüfschritt einheitlich auf 1.3.1c gesetzt. In Anleitung war irrtümlich 1.3.1f im Titel genannt.