### PR TITLE
11.1.4.3 Text-Kontraste: Anpassungen an Web-Test / Große Schriften in mm

### DIFF
--- a/Prüfschritte/de/11.1.4.3 Kontraste von Texten ausreichend.adoc
+++ b/Prüfschritte/de/11.1.4.3 Kontraste von Texten ausreichend.adoc
@@ -6,21 +6,12 @@ include::include/attributes.adoc[]
 
 Alle Texte der Software-Ansicht sollen ausreichende Helligkeitskontraste haben.
 Sie sollen auch für farbfehlsichtige Benutzer wahrnehmbar sein.
-Bei Ansichten, die eine ausreichend kontrastreiche Version über einen
-Styleswitcher anbieten, wird auch geprüft, ob der Ausgangszustand
-Mindestanforderungen an Schriftkontraste erfüllt.
 
 == Warum wird das geprüft?
 
 Wenn Vordergrund- und Hintergrundfarbe sich in der Helligkeit ähneln, haben
 sie unter Umständen zu wenig Kontrast, wenn sie mit Schwarzweiß-Monitoren
 oder von Menschen mit verschiedenen Arten von Farbenschwäche betrachtet werden.
-
-Die Ausgabe einer kontrastreicheren Ansicht durch einen Styleswitcher darf
-nicht dazu führen, dass die Standardansicht sich nicht mehr um nutzbare
-Kontraste kümmert.
-Denn viele Nutzer nehmen das Schaltelement Styleswitcher nicht wahr, verstehen
-die Funktion nicht, oder möchten die Software lieber im Ausgangszustand nutzen.
 
 == Wie wird geprüft?
 
@@ -52,12 +43,9 @@ Grafische Schriften sind ebenfalls Gegenstand des Prüfschritts.
 . Für Schriftgrößen unter 24 px (beziehungsweise 18,7 px bei fetter Schrift)
   prüfen, ob das Kontrastverhältnis bei 4,5:1 oder größer liegt.
   Zur Zeit ist die Bestimmung der genauen Schriftgröße auf mobilen Geräten
-  zum Teil nicht möglich bzw. nicht praktikabel.
+  zum Teil nur bedingt möglich bzw. nicht praktikabel.
 . Für große Schriften prüfen, ob das Kontrastverhältnis bei 3:1 oder
   größer liegt.
-. Bei andersfarbigen Fließtextlinks ohne sonstige Unterschiede in der
-  Auszeichnung, wie etwa Unterstreichung, prüfen, ob das Kontrastverhältnis
-  zum Standardfließtext mindestens 3:1 beträgt.
 
 ==== Styleswitcher-Prüfung
 

--- a/Prüfschritte/de/11.1.4.3 Kontraste von Texten ausreichend.adoc
+++ b/Prüfschritte/de/11.1.4.3 Kontraste von Texten ausreichend.adoc
@@ -111,7 +111,7 @@ Ansicht erfolgt nur unter folgenden Bedingungen:
 
 ===== Hinweise zur Messung des Kontrastverhältnisses
 
-NOTE: Für Apps z. Z. nur bedingt anwendbar.
+NOTE: Für Apps ist die Schriftgrößen-Unterscheidung z. Z. nur bedingt anwendbar.
 Die Ermittlung genauer Schriftgrößen ist bei Apps aufgrund fehlender
 Werkzeuge nicht oder nur ungenau möglich.
 Prüfer müssen an dieser Stelle anhand ihrer Erfahrung urteilen.

--- a/Prüfschritte/de/11.1.4.3 Kontraste von Texten ausreichend.adoc
+++ b/Prüfschritte/de/11.1.4.3 Kontraste von Texten ausreichend.adoc
@@ -72,15 +72,6 @@ Also zum Beispiel: auch die farblich hervorgehobene, aktuell ausgewählte
 Menüoption; auch in einer anderen Farbe dargestellte, besuchte Links.
 Für die Bewertung entscheidend ist der jeweils schlechtere Helligkeitskontrast.
 
-Die einzige Ausnahme, weil hier der gezielte Wechsel zwischen den beiden
-Zuständen verhältnismäßig einfach ist:
-die Hervorhebung des Maus- und Tastaturfokus.
-Hier soll zunächst geprüft werden, in welchem Zustand (im Fokus/nicht im
-Fokus) der Helligkeitskontrast besser ist.
-Dieser in Hinblick auf den Helligkeitskontrast bessere Zustand muss den
-allgemeinen Grenzwert von 4,5:1 erfüllen.
-Das Kontrastverhältnis des zweiten Zustandes muss über 3:1 liegen.
-
 Schwache Kontraste können zweckmäßig sein, sie können den Umgang mit einer
 App erleichtern.
 Ein Beispiel dafür:
@@ -120,9 +111,9 @@ Ansicht erfolgt nur unter folgenden Bedingungen:
 
 ===== Hinweise zur Messung des Kontrastverhältnisses
 
-NOTE: Für Apps z. Z. nicht anwendbar.
+NOTE: Für Apps z. Z. nur bedingt anwendbar.
 Die Ermittlung genauer Schriftgrößen ist bei Apps aufgrund fehlender
-Werkzeuge nicht möglich.
+Werkzeuge nicht oder nur ungenau möglich.
 Prüfer müssen an dieser Stelle anhand ihrer Erfahrung urteilen.
 Falls Ihnen geeignete Werkzeuge und Methoden bekannt sind, weisen Sie uns gerne
 darauf in einem https://github.com/BIK-BITV/BIK-App-Test/issues[GitHub Issue] hin.
@@ -135,8 +126,8 @@ an den gemessenen Werten der Schriftgröße in Pixel (Web Developer Toolbar,
 Funktion Elementinformationen einblenden), denn eine Messung der tatsächlich
 dargestellten Punktgröße auf dem Bildschirm mit einem Typometer ist nicht
 praktikabel.
-Bei einer Bildschirmauflösung von 96 dpi entsprechen 18 Punkt etwa 24 Pixeln,
-14 Punkt entsprechen etwa 18,7 Pixeln.
+Bei einer Bildschirmauflösung von 96 dpi entsprechen 18 Punkt etwa 24 Pixeln bzw. 6,35 mm,
+14 Punkt entsprechen etwa 18,7 Pixeln bzw. 4,94 mm.
 
 Die Messung des Pixel-Äquivalents ist dadurch gerechtfertigt, dass die bisher
 getesteten User Agents die Auszeichnung in Pixel und Punkt analog behandeln
@@ -159,8 +150,6 @@ Bildschirmauflösung, für den die Entsprechung auf jeden Fall gilt.
 * Das Kontrastverhältnis (contrast ratio) zwischen Vorder- und
   Hintergrundfarbe liegt bei Texten in großer Schriftgröße (18 Punkt und
   größer, 14 Punkt und größer bei fetter Schrift) bei mindestens 3:1.
-  Das Kontrastverhältnis des schlechteren Zustands des Maus- und
-  Tastaturfokus liegt über 3:1.
 
 * Wenn die Anforderung nur über eine alternative Ansicht erfüllt wird,
   erfüllt der Styleswicher selbst die Kontrastforderung von 4,5:1 und andere


### PR DESCRIPTION
Zum einen habe ich zwei Anpassungen gemacht, die im Web-Test bereits vorliegen. Der letzte Punkt ist neu zur Schriftgröße:

- Entfernung des 3:1-Kontrast für schlechteren Zustand aus Fokus/Nicht-Fokus von Bedienelementen
- Kontrastumschalter: Die Standardansicht muss keinen Mindestkontrast aufweisen (hier gab es Sätze in der Einführung des Prüfschritts)
- Messung Schriftgröße: Ein bestimmtes Tool ist mir nicht bekannt. Eventuell kann man Schriften mit dem Lineal nachmessen, obwohl das wahrscheinlich auch nur eingeschränkt zu empfehlen ist. Entsprechend der [CSS-Umrechung von pt auf mm](https://www.w3.org/TR/css-values-3/#absolute-lengths), die auch in den Quellen angegeben ist, habe ich die passenden Größen in mm für 18 pt und 14 pt angegeben. 