### PR TITLE
Update 11.2.4.7 Aktuelle Position des Fokus deutlich.adoc

### DIFF
--- a/Prüfschritte/de/11.2.4.7 Aktuelle Position des Fokus deutlich.adoc
+++ b/Prüfschritte/de/11.2.4.7 Aktuelle Position des Fokus deutlich.adoc
@@ -90,7 +90,6 @@ endif::env_embedded[]
 
 * Der System-Fokus wird unterdrückt, bei Tastaturnutzung wird kein Fokus
   angezeigt.
-  Hier muss eine Abwertung auf "schlecht zugänglich" erwogen werden.
 
 == Einordnung des Prüfschritts
 


### PR DESCRIPTION
Die Abwertungs-Möglichkeit existiert im BITV-Test seit ein paar Jahren nicht mehr. Sie sollte im Bewertung-Bereich entfernt werden, um keine Verwirrung zu verursachen.