### PR TITLE
11.5.2.16 Programmatisch steuerbare Zustände u. Eigenschaften - erster Entwurf

### DIFF
--- a/Prüfschritte/de/11.5.2.16 Programmatisch steuerbare Stati und Eigenschaften.adoc
+++ b/Prüfschritte/de/11.5.2.16 Programmatisch steuerbare Stati und Eigenschaften.adoc
@@ -22,7 +22,7 @@ Der Prüfschritt ist anwendbar, wenn die zu prüfende Ansicht Bedienelemente hat
 . Prüfen, ob sich Werte und Eigenschaften ändern lassen und der geänderte Wert vom Screenreader auch ausgelesen werden kann. 
 
 === 3. Hinweise
-Im wesentlichen spiegelt dieser Prüfschritt die Bewertung von 11.4.1.2 Name, Rolle, Wert wider. In den meisten Fällen kann hier auf die Bewertung in diesem Prüfschritt verwiesen werden.
+Im Wesentlichen spiegelt dieser Prüfschritt die Bewertung im Prüfschritt 11.4.1.2 Name, Rolle, Wert wider. In den meisten Fällen kann hier auf die Bewertung in diesem Prüfschritt verwiesen werden.
 
 Die Erreichbarkeit von Bedienelementen mit der Tastatur ist nicht Gegenstand dieses Prüfschritts. Bei nativen Apps wird Wischgesten-Navigation eingesetzt, um Beldienelemente zu kokussieren und deren Wert zu ändern. Hierbei sind auch Navigationsmodi einzusetzen, die die Änderugn des Werts etwa druch vertikale Wischbewegungen im jeweiligen Modus erlauben.
 

--- a/Prüfschritte/de/11.5.2.16 Programmatisch steuerbare Stati und Eigenschaften.adoc
+++ b/Prüfschritte/de/11.5.2.16 Programmatisch steuerbare Stati und Eigenschaften.adoc
@@ -17,8 +17,9 @@ Der Prüfschritt ist anwendbar, wenn die zu prüfende Ansicht Bedienelemente hat
 
 === 2. Prüfung
 
+. App mit zu prüfender Ansicht öffnen.
 . Bedienelemente auf der Ansicht ermitteln, bei denen sich von Nutzenden Zustände oder Eigenschaften ändern lassen.
-. Mit dem eingesetzten Screenreader Bedienelemente fokussieren.
+. Screenreader starten und Fokus mit Hilfe der Wischgeste auf jedes grafische Bedienelement setzen.
 . Prüfen, ob sich Werte und Eigenschaften ändern lassen und der geänderte Wert vom Screenreader auch ausgelesen werden kann. 
 
 === 3. Hinweise

--- a/Prüfschritte/de/11.5.2.16 Programmatisch steuerbare Stati und Eigenschaften.adoc
+++ b/Prüfschritte/de/11.5.2.16 Programmatisch steuerbare Stati und Eigenschaften.adoc
@@ -9,14 +9,27 @@ include::include/attributes.adoc[]
 == Wie wird das geprüft?
 
 === 1. Anwendbarkeit des Prüfschritts
+Der Prüfschritt ist anwendbar, wenn die zu prüfende Ansicht Bedienelemente hat, deren Zustände und Eigenschaften sich von Nutzenden ändern lassen. 
 
 === 2. Prüfung
+.Bedienelemente auf der Ansicht ermitteln, bie denen sich von Nutzenden Zustände oder Eigenschaften ändern lassen.
+.Mit dem eingesetzten Screenreader Bedienelemente fokussieren.
+.Prüfen, ob sich Werte und Eigenschaften ändern lassen und der geänderte Wert vom Screenreader auch ausgelesen werden kann. 
 
 === 3. Hinweise
+Im wesentlichen spiegelt dieser Prüfschritt die Bewertung von 11.4.1.2 Name, Rolle, Wert wider. In den meisten Fällen kann hier auf die Bewertung in diesem Prüfschritt verwiesen werden.
+
+Die Erreichbarkeit von Bedienelementen mit der Tastatur ist nicht Gegenstand dieses Prüfschritts. Bei nativen Apps wird Wischgesten-Navigation eingesetzt, um Beldienelemente zu kokussieren und deren Wert zu ändern. Hierbei sind auch Navigationsmodi einzusetzen, die die Änderugn des Werts etwa druch vertikale Wisdchbewegungen im jeweiligen Modus erlauben.
+
+Es wird nicht geprüft, ob ein initialer Wert ausgegeben wird. Nach Interaktion mit dem Bedienelement soll der eingestellte Wert aber ausgelesen werden können. Beispiele sind:
+* Eine Umsetzung einer Leiste mit Reitern gibt bei  Fokussierung den aktuell ausgewählten Reiter aus
+* Checkboxen lässt sich mit dem Screenreader bedienen und geben korrekt den jeweils gesetzten Wert aus
+* Bei einer Combobox, die dynamisch generierte Optionen in einer Ausklappliste erzeugt, lassen sich die Optionen erreichen und auswählen, der geänderte Wert der Combobox wid vom Screenreader bei Fokussierung ausgegeben
 
 === 4. Bewertung
 
 ==== Erfüllt:
+Alle Werte und Eigenschaften, die 
 
 == Einordnung des Prüfschritts
 

--- a/Prüfschritte/de/11.5.2.16 Programmatisch steuerbare Stati und Eigenschaften.adoc
+++ b/Prüfschritte/de/11.5.2.16 Programmatisch steuerbare Stati und Eigenschaften.adoc
@@ -12,16 +12,18 @@ include::include/attributes.adoc[]
 Der Prüfschritt ist anwendbar, wenn die zu prüfende Ansicht Bedienelemente hat, deren Zustände und Eigenschaften sich von Nutzenden ändern lassen. 
 
 === 2. Prüfung
-.Bedienelemente auf der Ansicht ermitteln, bie denen sich von Nutzenden Zustände oder Eigenschaften ändern lassen.
-.Mit dem eingesetzten Screenreader Bedienelemente fokussieren.
-.Prüfen, ob sich Werte und Eigenschaften ändern lassen und der geänderte Wert vom Screenreader auch ausgelesen werden kann. 
+
+. Bedienelemente auf der Ansicht ermitteln, bie denen sich von Nutzenden Zustände oder Eigenschaften ändern lassen.
+. Mit dem eingesetzten Screenreader Bedienelemente fokussieren.
+. Prüfen, ob sich Werte und Eigenschaften ändern lassen und der geänderte Wert vom Screenreader auch ausgelesen werden kann. 
 
 === 3. Hinweise
 Im wesentlichen spiegelt dieser Prüfschritt die Bewertung von 11.4.1.2 Name, Rolle, Wert wider. In den meisten Fällen kann hier auf die Bewertung in diesem Prüfschritt verwiesen werden.
 
-Die Erreichbarkeit von Bedienelementen mit der Tastatur ist nicht Gegenstand dieses Prüfschritts. Bei nativen Apps wird Wischgesten-Navigation eingesetzt, um Beldienelemente zu kokussieren und deren Wert zu ändern. Hierbei sind auch Navigationsmodi einzusetzen, die die Änderugn des Werts etwa druch vertikale Wisdchbewegungen im jeweiligen Modus erlauben.
+Die Erreichbarkeit von Bedienelementen mit der Tastatur ist nicht Gegenstand dieses Prüfschritts. Bei nativen Apps wird Wischgesten-Navigation eingesetzt, um Beldienelemente zu kokussieren und deren Wert zu ändern. Hierbei sind auch Navigationsmodi einzusetzen, die die Änderugn des Werts etwa druch vertikale Wischbewegungen im jeweiligen Modus erlauben.
 
 Es wird nicht geprüft, ob ein initialer Wert ausgegeben wird. Nach Interaktion mit dem Bedienelement soll der eingestellte Wert aber ausgelesen werden können. Beispiele sind:
+
 * Eine Umsetzung einer Leiste mit Reitern gibt bei  Fokussierung den aktuell ausgewählten Reiter aus
 * Checkboxen lässt sich mit dem Screenreader bedienen und geben korrekt den jeweils gesetzten Wert aus
 * Bei einer Combobox, die dynamisch generierte Optionen in einer Ausklappliste erzeugt, lassen sich die Optionen erreichen und auswählen, der geänderte Wert der Combobox wid vom Screenreader bei Fokussierung ausgegeben
@@ -29,7 +31,13 @@ Es wird nicht geprüft, ob ein initialer Wert ausgegeben wird. Nach Interaktion 
 === 4. Bewertung
 
 ==== Erfüllt:
-Alle Werte und Eigenschaften, die 
+
+* Alle Werte und Eigenschaften, die sich in der Ansicht ohne die Nutzung von Hilfsmittel anpassen lassen, sind auch bei Nutzung mit aktiviertem Screenreader anpassbar, der geänderte Wert oder Zustand kann mit dem Screenreader ausgelesen werden.
+
+==== Nicht erfüllt:
+
+* Werte oder Eigenschaften von Bedienelementen sind nicht mit dem Screenreader fokussierbar oder werden bei Fokussierung nicht ausgegeben.
+* Werte sind fokussierbar und werden ausgegeben, die Änderung des Wwrtes ist jedoch nicht möglich oder der Erfolg der Änderung kann mit dem Screenreader nicht ermittelt werden.
 
 == Einordnung des Prüfschritts
 

--- a/Prüfschritte/de/11.5.2.16 Programmatisch steuerbare Stati und Eigenschaften.adoc
+++ b/Prüfschritte/de/11.5.2.16 Programmatisch steuerbare Stati und Eigenschaften.adoc
@@ -4,7 +4,11 @@ include::include/attributes.adoc[]
 
 == Was wird geprüft?
 
+Apps sollen sich auch bei Nutzung von Hilfsmitteln vollumfänglich nutzen lassen. Dazu gehört die Änderung von Zuständen und Werten von Bedienelementen.
+
 == Warum wird das geprüft?
+
+Wenn Bedienelemente von Apps ihre Werte und Zustände nicht über die Barrierefreiheitsschnittstelle an Hilfsmittel übergeben und Änderungen von Werten und Zuständen sich nicht von Hilfsmittelnutzenden vornehmen lassen, sind diese Apps nicht oder nur eingeschränkt von diesen Menschen nutzbar. 
 
 == Wie wird das geprüft?
 

--- a/Prüfschritte/de/11.5.2.16 Programmatisch steuerbare Stati und Eigenschaften.adoc
+++ b/Prüfschritte/de/11.5.2.16 Programmatisch steuerbare Stati und Eigenschaften.adoc
@@ -17,19 +17,19 @@ Der Prüfschritt ist anwendbar, wenn die zu prüfende Ansicht Bedienelemente hat
 
 === 2. Prüfung
 
-. Bedienelemente auf der Ansicht ermitteln, bie denen sich von Nutzenden Zustände oder Eigenschaften ändern lassen.
+. Bedienelemente auf der Ansicht ermitteln, bei denen sich von Nutzenden Zustände oder Eigenschaften ändern lassen.
 . Mit dem eingesetzten Screenreader Bedienelemente fokussieren.
 . Prüfen, ob sich Werte und Eigenschaften ändern lassen und der geänderte Wert vom Screenreader auch ausgelesen werden kann. 
 
 === 3. Hinweise
 Im Wesentlichen spiegelt dieser Prüfschritt die Bewertung im Prüfschritt 11.4.1.2 Name, Rolle, Wert wider. In den meisten Fällen kann hier auf die Bewertung in diesem Prüfschritt verwiesen werden.
 
-Die Erreichbarkeit von Bedienelementen mit der Tastatur ist nicht Gegenstand dieses Prüfschritts. Bei nativen Apps wird Wischgesten-Navigation eingesetzt, um Beldienelemente zu kokussieren und deren Wert zu ändern. Hierbei sind auch Navigationsmodi einzusetzen, die die Änderugn des Werts etwa druch vertikale Wischbewegungen im jeweiligen Modus erlauben.
+Die Erreichbarkeit von Bedienelementen mit der Tastatur ist nicht Gegenstand dieses Prüfschritts. Bei nativen Apps wird Wischgesten-Navigation eingesetzt, um Bedienelemente zu fokussieren und deren Wert zu ändern. Hierbei sind auch Navigationsmodi einzusetzen, die die Änderung des Werts etwa durch vertikale Wischbewegungen im jeweiligen Modus erlauben.
 
 Es wird nicht geprüft, ob ein initialer Wert ausgegeben wird. Nach Interaktion mit dem Bedienelement soll der eingestellte Wert aber ausgelesen werden können. Beispiele sind:
 
-* Eine Umsetzung einer Leiste mit Reitern gibt bei  Fokussierung den aktuell ausgewählten Reiter aus
-* Checkboxen lässt sich mit dem Screenreader bedienen und geben korrekt den jeweils gesetzten Wert aus
+* Eine Umsetzung einer Leiste mit Reitern gibt bei Fokussierung den aktuell ausgewählten Reiter aus
+* Checkboxen und Inputs mit `type="radio"` lassen sich mit dem Screenreader bedienen und geben korrekt den jeweils gesetzten Wert aus
 * Bei einer Combobox, die dynamisch generierte Optionen in einer Ausklappliste erzeugt, lassen sich die Optionen erreichen und auswählen, der geänderte Wert der Combobox wid vom Screenreader bei Fokussierung ausgegeben
 
 === 4. Bewertung
@@ -41,7 +41,8 @@ Es wird nicht geprüft, ob ein initialer Wert ausgegeben wird. Nach Interaktion 
 ==== Nicht erfüllt:
 
 * Werte oder Eigenschaften von Bedienelementen sind nicht mit dem Screenreader fokussierbar oder werden bei Fokussierung nicht ausgegeben.
-* Werte sind fokussierbar und werden ausgegeben, die Änderung des Wwrtes ist jedoch nicht möglich oder der Erfolg der Änderung kann mit dem Screenreader nicht ermittelt werden.
+* Werte sind fokussierbar und werden ausgegeben, die Änderung des Wertes ist jedoch nicht möglich
+* Änderungen von Werten oder Zuständen sind möglich, der Erfolg der Änderung kann mit dem Screenreader aber nicht ermittelt werden.
 
 == Einordnung des Prüfschritts
 

--- a/Prüfschritte/de/11.5.2.16 Programmatisch steuerbare Stati und Eigenschaften.adoc
+++ b/Prüfschritte/de/11.5.2.16 Programmatisch steuerbare Stati und Eigenschaften.adoc
@@ -19,7 +19,7 @@ Der Prüfschritt ist anwendbar, wenn die zu prüfende Ansicht Bedienelemente hat
 
 . App mit zu prüfender Ansicht öffnen.
 . Bedienelemente auf der Ansicht ermitteln, bei denen sich von Nutzenden Zustände oder Eigenschaften ändern lassen.
-. Screenreader starten und Fokus mit Hilfe der Wischgeste auf jedes grafische Bedienelement setzen.
+. Screenreader starten und Fokus mit Hilfe der Wischgeste entsprechende Bedienelemente setzen.
 . Prüfen, ob sich Werte und Eigenschaften ändern lassen und der geänderte Wert vom Screenreader auch ausgelesen werden kann. 
 
 === 3. Hinweise


### PR DESCRIPTION
Was wir hier brauchen könnten, ist ein Statement (möglichst mit praktischen Beispielen) in welchen Fällen die Prüfung hier über die in 11.4.1.2 hinausgeht. In beiden Fällen wird ja die Ausgabe des Screenreaders eingesetzt, und es ist nicht entscheidbar, ob der Screenreader einen Wert nicht ausgibt, weil er das jeweilige Element nicht (ausreichend) unterstützt, oder ob die Umsetzung fehlerhaft ist.
[Zur Leseansicht von 11.5.2.16 Programmatisch steuerbare Zustände u. Eigenschaften](https://github.com/BIK-BITV/BIK-App-Test/blob/befc9a195ac3837190f433e38a892f02eecc3346/Pr%C3%BCfschritte/de/11.5.2.16%20Programmatisch%20steuerbare%20Stati%20und%20Eigenschaften.adoc)

Ich würde statt "Stati" "Zustände" vorziehen. Spricht etwas dagegen?