### PR TITLE
Update 11.5.2.8 Programmatisch ermittelbare Beschriftungen.adoc

### DIFF
--- a/Prüfschritte/de/11.5.2.8 Programmatisch ermittelbare Beschriftungen.adoc
+++ b/Prüfschritte/de/11.5.2.8 Programmatisch ermittelbare Beschriftungen.adoc
@@ -35,6 +35,7 @@ Der Prüfschritt ist anwendbar, wenn Bedienelemente eingesetzt werden, die ledig
 
 * Im Wesentlichen gleicht die Prüfung in diesem Prüfschritt der Prüfung in Prüfschritt 11.1.3.1e "Beschriftung von Formularelementen programmatisch ermittelbar". In der Regel kann einfach auf diesen Prüfschritt verwiesen werden.
 * Ob das vom Screenreader ausgegebene Accessibility-Label wirklich vom beschriftenden Element stammt oder getrennt als AccessibilityLabel hinterlegt ist, kann nicht festgestellt werden. Hier kann nur festgestellt werden, ob das AccessibilityLabel eines Bedienelements gleichlautend mit der nebenstehenden Beschriftung ist.
+* Es wird hier nicht negativ bewertet, wenn die programmatische und die sichtbare Beschriftung nicht identisch sind bzw. die sichtbare Beschriftung nicht im zugänglichen Namen enthalten ist. Dies ist Gegenstand von Prüfschritt 11.2.5.3 "Sichtbare Beschriftung Teil des zugänglichen Namens".
 
 === 4. Bewertung
 

--- a/Prüfschritte/de/11.5.2.8 Programmatisch ermittelbare Beschriftungen.adoc
+++ b/Prüfschritte/de/11.5.2.8 Programmatisch ermittelbare Beschriftungen.adoc
@@ -13,7 +13,7 @@ Programmatisch ermittelbar ist die Beschriftung des Eingabefelds in diesem Fall,
 
 Screenreader geben die Elemente auf dem Bildschirm nacheinander aus,  eine visuell vermittelte Verbindung von Bedienelementen und Beschriftungen können Nutzer dieser assistiven Software nicht immer in vergleichbarer Weise herstellen. 
 In manchen Screenreader-Navigationsmodi werden bestimmte Elemente gezielt durchlaufen, etwa nur Steuerelemente. Wird ein Element, etwa ein Eingabefeld, auf diese Weise fokussiert, soll die programmatisch zugeordnete oder hinterlegte Beschriftung ausgegeben werden.
-Bedienelemente müssen daher auch die Zuordnung der Beschriftung visuell klar ist, eine programmatisch ermittelbare Beschriftung haben, um eine effiziente Bedienung zu ermöglichen.
+Bedienelemente müssen daher, auch wenn die Zuordnung der Beschriftung visuell klar ist, eine programmatisch ermittelbare Beschriftung haben, um eine effiziente Bedienung zu ermöglichen.
 
 Damit die Beschriftungsinformation nicht doppelt durch den Entwickler gepflegt werden muss (sichtbare Beschriftung und Accessibility-Label), soll das Bedienelement ohne Beschriftung programmatisch auf dessen Beschriftung verweisen.
 Sobald sich die Beschriftung ändert, erhält das Bedienelement ohne sichtbare Beschriftung ebenfalls den neuen Text und kann diesen als Accessibility-Label an das System melden.

--- a/Prüfschritte/de/11.5.2.8 Programmatisch ermittelbare Beschriftungen.adoc
+++ b/Prüfschritte/de/11.5.2.8 Programmatisch ermittelbare Beschriftungen.adoc
@@ -16,9 +16,7 @@ In manchen Screenreader-Navigationsmodi werden bestimmte Elemente gezielt durchl
 Bedienelemente müssen daher, auch wenn die Zuordnung der Beschriftung visuell klar ist, eine programmatisch ermittelbare Beschriftung haben, um eine effiziente Bedienung zu ermöglichen.
 
 Damit die Beschriftungsinformation nicht doppelt durch den Entwickler gepflegt werden muss (sichtbare Beschriftung und Accessibility-Label), soll das Bedienelement ohne Beschriftung programmatisch auf dessen Beschriftung verweisen.
-Sobald sich die Beschriftung ändert, erhält das Bedienelement ohne sichtbare Beschriftung ebenfalls den neuen Text und kann diesen als Accessibility-Label an das System melden.
-Der Screenreader kann somit beim Antippen des Bedienelements ohne sichtbare Beschriftung ein passendes Label ausgeben.
-Diese Art, ein Accessibility-Label bereitzustellen, ist robuster als die separate Pflege von sichtbarer Beschriftung und einem Accessibility-Label.
+Sobald sich die Beschriftung ändert, erhält das Bedienelement ohne sichtbare Beschriftung ebenfalls ein aktualisiertes Accessibility-Label und kann so beim Fokussieren des Bedienelements ohne sichtbare Beschriftung die aktuelle Beschriftung ausgeben. Diese Art, ein Accessibility-Label bereitzustellen, ist robuster als die separate Pflege von sichtbarer Beschriftung und einem Accessibility-Label.
 
 == Wie wird das geprüft?
 

--- a/Prüfschritte/de/11.5.2.8 Programmatisch ermittelbare Beschriftungen.adoc
+++ b/Prüfschritte/de/11.5.2.8 Programmatisch ermittelbare Beschriftungen.adoc
@@ -18,7 +18,7 @@ Bedienelemente müssen daher, auch wenn die Zuordnung der Beschriftung visuell k
 Damit die Beschriftungsinformation nicht doppelt durch den Entwickler gepflegt werden muss (sichtbare Beschriftung und Accessibility-Label), soll das Bedienelement ohne Beschriftung programmatisch auf dessen Beschriftung verweisen.
 Sobald sich die Beschriftung ändert, erhält das Bedienelement ohne sichtbare Beschriftung ebenfalls den neuen Text und kann diesen als Accessibility-Label an das System melden.
 Der Screenreader kann somit beim Antippen des Bedienelements ohne sichtbare Beschriftung ein passendes Label ausgeben.
-Diese Art, ein Accessibility-Label bereitzustellen ist robuster als die separate Pflege von sichtbarer Beschriftung und einem Accessibility-Label.
+Diese Art, ein Accessibility-Label bereitzustellen, ist robuster als die separate Pflege von sichtbarer Beschriftung und einem Accessibility-Label.
 
 == Wie wird das geprüft?
 
@@ -34,7 +34,7 @@ Der Prüfschritt ist anwendbar, wenn Bedienelemente eingesetzt werden, die ledig
 === 3. Hinweise
 
 * Im Wesentlichen gleicht die Prüfung in diesem Prüfschritt der Prüfung in Prüfschritt 11.1.3.1e "Beschriftung von Formularelementen programmatisch ermittelbar". In der Regel kann einfach auf diesen Prüfschritt verwiesen werden.
-* Ob das vom Screenreader ausgegebene Accessibility-Label wirklich vom beschriftenden Element stammt oder getrennt als AccessibilityLabel hinterlegt ist, kann nicht festgestellt werden. Hier kann nur festgestellt werden, ob das AccessibilityLabel eines Bedienelements gleichlautend mit der nebenstehenden Beschriftung ist.
+* Ob das vom Screenreader ausgegebene Accessibility-Label wirklich vom beschriftenden Element stammt oder getrennt als AccessibilityLabel hinterlegt ist, kann nicht festgestellt werden, wenn beide gleichlautend sind.
 * Es wird hier nicht negativ bewertet, wenn die programmatische und die sichtbare Beschriftung nicht identisch sind bzw. die sichtbare Beschriftung nicht im zugänglichen Namen enthalten ist. Dies ist Gegenstand von Prüfschritt 11.2.5.3 "Sichtbare Beschriftung Teil des zugänglichen Namens".
 
 === 4. Bewertung

--- a/Prüfschritte/de/11.5.2.8 Programmatisch ermittelbare Beschriftungen.adoc
+++ b/Prüfschritte/de/11.5.2.8 Programmatisch ermittelbare Beschriftungen.adoc
@@ -33,8 +33,8 @@ Der Prüfschritt ist anwendbar, wenn Bedienelemente eingesetzt werden, die ledig
 
 === 3. Hinweise
 
-Ob das vom Screenreader ausgegebene Accessibility-Label wirklich vom beschriftenden Element stammt oder getrennt als AccessibilityLabel hinterlegt ist, kann nicht festgestellt werden.
-Hier kann nur geprüft werden, ob das Accessibility-Label, für das Bedienelement ohne sichtbare Beschriftung, gleichlautend zur Beschriftung des beschriftenden Elements ist.
+* Im Wesentlichen gleicht die Prüfung in diesem Prüfschritt der Prüfung in Prüfschritt 11.1.3.1e "Beschriftung von Formularelementen programmatisch ermittelbar". In der Regel kann einfach auf diesen Prüfschritt verwiesen werden.
+* Ob das vom Screenreader ausgegebene Accessibility-Label wirklich vom beschriftenden Element stammt oder getrennt als AccessibilityLabel hinterlegt ist, kann nicht festgestellt werden. Hier kann nur festgestellt werden, ob das Accessibility-Label eines Bedienelements gleichlautend mit der nebenstehenden Beschriftung ist.
 
 === 4. Bewertung
 

--- a/Prüfschritte/de/11.5.2.8 Programmatisch ermittelbare Beschriftungen.adoc
+++ b/Prüfschritte/de/11.5.2.8 Programmatisch ermittelbare Beschriftungen.adoc
@@ -7,13 +7,11 @@ include::include/attributes.adoc[]
 UI-Elemente, die durch andere UI-Elemente beschriftet werden, sollen diese Beschriftung programmatisch ermittelbar zur Verfügung stellen.
 Ein Eingabefeld, das lediglich durch einen nebenstehenden Button beschriftet wird, soll zum Beispiel selbst die Beschriftung, die es durch den Button erhält, programmatisch zur Verfügung stellen.
 Diese Art der Beschriftung taucht zum Beispiel häufig bei Suchfunktionen auf: Ein Button folgt auf ein Eingabefeld, nur der Button ist mit "Suchen" beschriftet.
-Programmatisch ermittelbar ist die Beschriftung des Eingabefelds in diesem Fall, wenn die Beschriftung "Suchen" beim Antippen des Eingabefelds mit aktiviertem Screenreader vorgelesen wird.
+Programmatisch ermittelbar ist die Beschriftung des Eingabefelds in diesem Fall, wenn die Beschriftung "Suchen" beim Fokussieren des Eingabefelds mit aktiviertem Screenreader vorgelesen wird. Auch ein Antippen des Elements führt zu dieser Ausgabe.
 
 == Warum wird das geprüft?
 
-Screenreader geben die Elemente auf dem Bildschirm nacheinander aus,  eine visuell vermittelte Verbindung von Bedienelementen und Beschriftungen können Nutzer dieser assistiven Software nicht immer in vergleichbarer Weise herstellen. 
-In manchen Screenreader-Navigationsmodi werden bestimmte Elemente gezielt durchlaufen, etwa nur Steuerelemente. Wird ein Element, etwa ein Eingabefeld, auf diese Weise fokussiert, soll die programmatisch zugeordnete oder hinterlegte Beschriftung ausgegeben werden.
-Bedienelemente müssen daher, auch wenn die Zuordnung der Beschriftung visuell klar ist, eine programmatisch ermittelbare Beschriftung haben, um eine effiziente Bedienung zu ermöglichen.
+Screenreader geben die Elemente auf dem Bildschirm nacheinander aus. Den visuellen Zusammenhang zwischen Bedienelement und Beschriftung können Nutzer dieser assistiven Software nicht immer in vergleichbarer Weise herstellen. So werden in manchen Screenreader-Navigationsmodi bestimmte Elemente gezielt durchlaufen, etwa nur Steuerelemente. Wird ein Element, etwa ein Eingabefeld, auf diese Weise fokussiert, soll die programmatisch zugeordnete oder hinterlegte Beschriftung ausgegeben werden. Bedienelemente müssen daher, auch wenn die Zuordnung der Beschriftung visuell klar ist, eine programmatisch ermittelbare Beschriftung haben, um eine effiziente Bedienung zu ermöglichen.
 
 Damit die Beschriftungsinformation nicht doppelt durch den Entwickler gepflegt werden muss (sichtbare Beschriftung und Accessibility-Label), soll das Bedienelement ohne Beschriftung programmatisch auf dessen Beschriftung verweisen.
 Sobald sich die Beschriftung ändert, erhält das Bedienelement ohne sichtbare Beschriftung ebenfalls ein aktualisiertes Accessibility-Label und kann so beim Fokussieren des Bedienelements ohne sichtbare Beschriftung die aktuelle Beschriftung ausgeben. Diese Art, ein Accessibility-Label bereitzustellen, ist robuster als die separate Pflege von sichtbarer Beschriftung und einem Accessibility-Label.

--- a/Prüfschritte/de/11.5.2.8 Programmatisch ermittelbare Beschriftungen.adoc
+++ b/Prüfschritte/de/11.5.2.8 Programmatisch ermittelbare Beschriftungen.adoc
@@ -11,10 +11,9 @@ Programmatisch ermittelbar ist die Beschriftung des Eingabefelds in diesem Fall,
 
 == Warum wird das geprüft?
 
-Screenreader geben die Elemente auf dem Bildschirm nacheinander aus. Den visuellen Zusammenhang zwischen Bedienelement und Beschriftung können Nutzer dieser assistiven Software nicht immer in vergleichbarer Weise herstellen. So werden in manchen Screenreader-Navigationsmodi bestimmte Elemente gezielt durchlaufen, etwa nur Steuerelemente. Wird ein Element, etwa ein Eingabefeld, auf diese Weise fokussiert, soll die programmatisch zugeordnete oder hinterlegte Beschriftung ausgegeben werden. Bedienelemente müssen daher, auch wenn die Zuordnung der Beschriftung visuell klar ist, eine programmatisch ermittelbare Beschriftung haben, um eine effiziente Bedienung zu ermöglichen.
+Screenreader geben die Elemente auf dem Bildschirm nacheinander aus. Den visuellen Zusammenhang zwischen Bedienelement und Beschriftung können Screenreader-Nutzende nicht immer in vergleichbarer Weise herstellen. So werden in manchen Screenreader-Navigationsmodi bestimmte Elemente gezielt durchlaufen, etwa nur Steuerelemente. Wird ein Element, etwa ein Eingabefeld, auf diese Weise fokussiert, soll die programmatisch zugeordnete oder hinterlegte Beschriftung ausgegeben werden. Bedienelemente müssen daher, auch wenn die Zuordnung der Beschriftung visuell klar ist, eine programmatisch ermittelbare Beschriftung haben, um eine effiziente Bedienung zu ermöglichen.
 
-Damit die Beschriftungsinformation nicht doppelt durch den Entwickler gepflegt werden muss (sichtbare Beschriftung und Accessibility-Label), soll das Bedienelement ohne Beschriftung programmatisch auf dessen Beschriftung verweisen.
-Sobald sich die Beschriftung ändert, erhält das Bedienelement ohne sichtbare Beschriftung ebenfalls ein aktualisiertes Accessibility-Label und kann so beim Fokussieren des Bedienelements ohne sichtbare Beschriftung die aktuelle Beschriftung ausgeben. Diese Art, ein Accessibility-Label bereitzustellen, ist robuster als die separate Pflege von sichtbarer Beschriftung und einem Accessibility-Label.
+Damit die Beschriftungsinformation nicht doppelt gepflegt werden muss (sichtbare Beschriftung und Accessibility-Label), sollten Bedienelemente ohne Beschriftung programmatisch auf deren nebenstehende Beschriftung verweisen. Sobald sich die Beschriftung ändert, erhält das Bedienelement ohne sichtbare Beschriftung dann ebenfalls ein aktualisiertes Accessibility-Label. So kann beim Fokussieren des Bedienelements ohne sichtbare Beschriftung die aktuelle Beschriftung ausgeben werden. Diese Art, ein Accessibility-Label bereitzustellen, ist robuster als die separate Pflege von sichtbarer Beschriftung und einem Accessibility-Label.
 
 == Wie wird das geprüft?
 
@@ -25,7 +24,7 @@ Der Prüfschritt ist anwendbar, wenn Bedienelemente eingesetzt werden, die ledig
 === 2. Prüfung
 
 . Screenreader starten
-. Bedienelemente mit nebenstehender Beschriftung mit dem Screenreader fokussieren. Es sollte jeweils die nebenstehende sichtbare Beschriftung oder eine gleichwertige programmatisch hinterlegte Beschriftung ausgegeben werden.
+. Bedienelemente mit nebenstehender Beschriftung mit dem Screenreader fokussieren. Es sollte jeweils die nebenstehende sichtbare Beschriftung (oder eine gleichwertige programmatisch hinterlegte Beschriftung) ausgegeben werden.
 
 === 3. Hinweise
 

--- a/Prüfschritte/de/11.5.2.8 Programmatisch ermittelbare Beschriftungen.adoc
+++ b/Prüfschritte/de/11.5.2.8 Programmatisch ermittelbare Beschriftungen.adoc
@@ -28,18 +28,25 @@ Der Prüfschritt ist anwendbar, wenn Bedienelemente eingesetzt werden, die ledig
 === 2. Prüfung
 
 . Screenreader starten
-. auf Bedienelement ohne Beschriftung tippen, es sollte die Beschriftung des beschrifteten Bedienelements ausgegeben werden
+. Bedienelement mit nebenstehender Beschriftung mit dem Screenreader fokussieren. Es sollte die nebenstehende Beschriftung ausgegeben werden.
 
 === 3. Hinweise
 
-Ob das vom Screenreader ausgegebene Accessibility-Label wirklich vom beschriftenden UI-Element stammt, kann nicht mit letzter Gewissheit festgestellt werden.
+Ob das vom Screenreader ausgegebene Accessibility-Label wirklich vom beschriftenden Element stammt oder getrennt als AccessibilityLabel hinterlegt ist, kann nicht festgestellt werden.
 Hier kann nur geprüft werden, ob das Accessibility-Label, für das Bedienelement ohne sichtbare Beschriftung, gleichlautend zur Beschriftung des beschriftenden Elements ist.
 
 === 4. Bewertung
 
 ==== Erfüllt:
 
+* Bei Fokussierung von Bedienelementen mit nebenstehender Beschriftung wird diese Beschiftung als Name ausgegeben.
+* Ein gleichwertiger, programmatisch hinterlegter Name wird bei Fokussierung des Bedienelements ausgegeben. 
+
 == Einordnung des Prüfschritts
+
+=== Abgrenzung des Prüfschritts
+
+In Prüfschritt 11.2.5.3 "Sichtbare Beschriftung Teil des zugänglichen Namens" wird geprüft, ob die sichtbare Beschriftung im programmatisch ermittelbaren Namen des Bedienelements vorkommt. Es kann also Fälle geben, wo dieser Prüfschritt erfüllt ist, da statt der Verknüpfung der sichtbaren Beschriftung eine hinterlegte gleichwertige Beschriftung programmatisch ermittelbar ist, jedoch Prüfschritt 11.2.5.3 nicht erfüllt wäre, wenn die exakte Zeichenfolge der sichtbaren Beschriftung nicht im programmatisch ermittelbaren Namen vorkommt.
 
 === Einordnung des Prüfschritts nach EN 301 549 V3.1.1
 

--- a/Prüfschritte/de/11.5.2.8 Programmatisch ermittelbare Beschriftungen.adoc
+++ b/Prüfschritte/de/11.5.2.8 Programmatisch ermittelbare Beschriftungen.adoc
@@ -11,7 +11,8 @@ Programmatisch ermittelbar ist die Beschriftung des Eingabefelds in diesem Fall,
 
 == Warum wird das geprüft?
 
-Screenreader geben die Elemente auf dem Bildschirm nacheinander aus,  eine visuell vermittelte Verbindung von Bedien- und anderen UI-Elementen zueinander können Nutzer dieser assistiven Software nicht immer in vergleichbarer Weise herstellen. In manchen Screenreader-Navigationsmodi werden bestimmte Elemente gezielt druchlaufen, etwa nut Steuerelemente. Wird ein Element, etwa ein Eingabefeld, auf diese Weise fokussiert, soll die programmatisch zugeordnete oder hinterlegte Beschriftung ausgegeben werden
+Screenreader geben die Elemente auf dem Bildschirm nacheinander aus,  eine visuell vermittelte Verbindung von Bedienelementen und Beschriftungen können Nutzer dieser assistiven Software nicht immer in vergleichbarer Weise herstellen. 
+In manchen Screenreader-Navigationsmodi werden bestimmte Elemente gezielt durchlaufen, etwa nur Steuerelemente. Wird ein Element, etwa ein Eingabefeld, auf diese Weise fokussiert, soll die programmatisch zugeordnete oder hinterlegte Beschriftung ausgegeben werden.
 Bedienelemente müssen daher auch die Zuordnung der Beschriftung visuell klar ist, eine programmatisch ermittelbare Beschriftung haben, um eine effiziente Bedienung zu ermöglichen.
 
 Damit die Beschriftungsinformation nicht doppelt durch den Entwickler gepflegt werden muss (sichtbare Beschriftung und Accessibility-Label), soll das Bedienelement ohne Beschriftung programmatisch auf dessen Beschriftung verweisen.
@@ -28,7 +29,7 @@ Der Prüfschritt ist anwendbar, wenn Bedienelemente eingesetzt werden, die ledig
 === 2. Prüfung
 
 . Screenreader starten
-. Bedienelement mit nebenstehender Beschriftung mit dem Screenreader fokussieren. Es sollte die nebenstehende Beschriftung ausgegeben werden.
+. Bedienelemente mit nebenstehender Beschriftung mit dem Screenreader fokussieren. Es sollte jeweils die nebenstehende sichtbare Beschriftung oder eine gleichwertige programmatisch hinterlegte Beschriftung ausgegeben werden.
 
 === 3. Hinweise
 

--- a/Prüfschritte/de/11.5.2.8 Programmatisch ermittelbare Beschriftungen.adoc
+++ b/Prüfschritte/de/11.5.2.8 Programmatisch ermittelbare Beschriftungen.adoc
@@ -34,7 +34,7 @@ Der Prüfschritt ist anwendbar, wenn Bedienelemente eingesetzt werden, die ledig
 === 3. Hinweise
 
 * Im Wesentlichen gleicht die Prüfung in diesem Prüfschritt der Prüfung in Prüfschritt 11.1.3.1e "Beschriftung von Formularelementen programmatisch ermittelbar". In der Regel kann einfach auf diesen Prüfschritt verwiesen werden.
-* Ob das vom Screenreader ausgegebene Accessibility-Label wirklich vom beschriftenden Element stammt oder getrennt als AccessibilityLabel hinterlegt ist, kann nicht festgestellt werden. Hier kann nur festgestellt werden, ob das Accessibility-Label eines Bedienelements gleichlautend mit der nebenstehenden Beschriftung ist.
+* Ob das vom Screenreader ausgegebene Accessibility-Label wirklich vom beschriftenden Element stammt oder getrennt als AccessibilityLabel hinterlegt ist, kann nicht festgestellt werden. Hier kann nur festgestellt werden, ob das AccessibilityLabel eines Bedienelements gleichlautend mit der nebenstehenden Beschriftung ist.
 
 === 4. Bewertung
 

--- a/Prüfschritte/de/11.5.2.8 Programmatisch ermittelbare Beschriftungen.adoc
+++ b/Prüfschritte/de/11.5.2.8 Programmatisch ermittelbare Beschriftungen.adoc
@@ -5,18 +5,18 @@ include::include/attributes.adoc[]
 == Was wird geprüft?
 
 UI-Elemente, die durch andere UI-Elemente beschriftet werden, sollen diese Beschriftung programmatisch ermittelbar zur Verfügung stellen.
-Ein Eingabefeld, das lediglich durch einen nebenstehenden Button beschriftet wird, soll zum Beispiel  selbst die Beschriftung, die es durch den Button erhält, programmatisch zur Verfügung stellen.
-Diese Art der Beschriftung taucht bspw. häufig bei Suchfunktionen auf, ein Button folgt auf ein Eingabefeld, nur der Button ist mit "suchen" beschriftet.
-Programmatisch ermittelbar ist die Beschriftung des Eingabefelds in diesem Fall, wenn die Beschriftung "suchen" beim Antippen des Eingabefelds mit aktiviertem Screenreader vorgelesen wird.
+Ein Eingabefeld, das lediglich durch einen nebenstehenden Button beschriftet wird, soll zum Beispiel selbst die Beschriftung, die es durch den Button erhält, programmatisch zur Verfügung stellen.
+Diese Art der Beschriftung taucht zum Beispiel häufig bei Suchfunktionen auf: Ein Button folgt auf ein Eingabefeld, nur der Button ist mit "Suchen" beschriftet.
+Programmatisch ermittelbar ist die Beschriftung des Eingabefelds in diesem Fall, wenn die Beschriftung "Suchen" beim Antippen des Eingabefelds mit aktiviertem Screenreader vorgelesen wird.
 
 == Warum wird das geprüft?
 
-Screenreader geben die Elemente auf dem Bildschirm nacheinander aus,  eine visuell vermittelte Verbindung von Bedien- und anderen UI-elementen zueinander können Nutzer dieser assistiven Software  nicht immer  in vergleichbarer Weise herstellen.
-Bedienelemente müssen daher auch, wenn sie im Verbund eingesetzt werden, jeweils einzeln eine programmatisch ermittelbare Beschriftung erhalten, um eine effiziente und leicht zu verstehende Bedienung zu ermöglichen.
+Screenreader geben die Elemente auf dem Bildschirm nacheinander aus,  eine visuell vermittelte Verbindung von Bedien- und anderen UI-Elementen zueinander können Nutzer dieser assistiven Software nicht immer in vergleichbarer Weise herstellen. In manchen Screenreader-Navigationsmodi werden bestimmte Elemente gezielt druchlaufen, etwa nut Steuerelemente. Wird ein Element, etwa ein Eingabefeld, auf diese Weise fokussiert, soll die programmatisch zugeordnete oder hinterlegte Beschriftung ausgegeben werden
+Bedienelemente müssen daher auch die Zuordnung der Beschriftung visuell klar ist, eine programmatisch ermittelbare Beschriftung haben, um eine effiziente Bedienung zu ermöglichen.
 
-Damit die Beschriftungsinformation nicht doppelt durch den Entwickler gepflegt werden muss (sichtbare Beschriftung und Accessibility-Label), soll das Bedienelement ohne Beschriftung programmatisch auf die Beschriftung des beschriftenden Bedienelements verweisen.
+Damit die Beschriftungsinformation nicht doppelt durch den Entwickler gepflegt werden muss (sichtbare Beschriftung und Accessibility-Label), soll das Bedienelement ohne Beschriftung programmatisch auf dessen Beschriftung verweisen.
 Sobald sich die Beschriftung ändert, erhält das Bedienelement ohne sichtbare Beschriftung ebenfalls den neuen Text und kann diesen als Accessibility-Label an das System melden.
-Der Screenreader kann somit beim antippen des Bedienelements ohne sichtbare Beschriftung ein passendes Label ausgeben.
+Der Screenreader kann somit beim Antippen des Bedienelements ohne sichtbare Beschriftung ein passendes Label ausgeben.
 Diese Art, ein Accessibility-Label bereitzustellen ist robuster als die separate Pflege von sichtbarer Beschriftung und einem Accessibility-Label.
 
 == Wie wird das geprüft?
@@ -32,7 +32,7 @@ Der Prüfschritt ist anwendbar, wenn Bedienelemente eingesetzt werden, die ledig
 
 === 3. Hinweise
 
-Ob das vom Screenreader ausgegebene Accessibility-Label wirklich vom beschriftenden UI-Element stammt, kannnicht mit letzter Gewissheit festgestellt werden.
+Ob das vom Screenreader ausgegebene Accessibility-Label wirklich vom beschriftenden UI-Element stammt, kann nicht mit letzter Gewissheit festgestellt werden.
 Hier kann nur geprüft werden, ob das Accessibility-Label, für das Bedienelement ohne sichtbare Beschriftung, gleichlautend zur Beschriftung des beschriftenden Elements ist.
 
 === 4. Bewertung


### PR DESCRIPTION
Unklar ist mir für die Prüfung die Bedeutung von:
> "Sobald sich die Beschriftung ändert, erhält das Bedienelement ohne sichtbare Beschriftung ebenfalls den neuen Text und kann diesen als Accessibility-Label an das System melden. Der Screenreader kann somit beim Antippen des Bedienelements ohne sichtbare Beschriftung ein passendes Label ausgeben.
Diese Art, ein Accessibility-Label bereitzustellen ist robuster als die separate Pflege von sichtbarer Beschriftung und einem Accessibility-Label."
[Leseansicht von 11.5.2.8 Programmatisch ermittelbare Beschriftungen](https://github.com/BIK-BITV/BIK-App-Test/blob/32817b92970017a4298526922c7f655be30af39e/Pr%C3%BCfschritte/de/11.5.2.8%20Programmatisch%20ermittelbare%20Beschriftungen.adoc)

* Noch zu klären wäre, ob die Intention von 11.5.2.8 noch über 11.1.3.1d hinausgeht, indem verlangt würde, dass die Beschirftung immer identisch - und nicht nur gleichwertig - mit dem sichtbaren Label wäre.
*  Ich vermute, der Abschnitt "Damit die Beschriftungsinformation nicht doppelt durch den Entwickler gepflegt werden muss..." kann eigentlich entfallen - ich sehe nicht, wie er für die Prüfung relevant wäre.