### PR TITLE
Update 11.5.2.13/14 Ausgabe/Steuerung Fokus, Texteinfügemarke, Textmarkierung

### DIFF
--- a/Prüfschritte/de/11.5.2.13 Fokusverfolgung Texteinfügemarke und Textauswahl.adoc
+++ b/Prüfschritte/de/11.5.2.13 Fokusverfolgung Texteinfügemarke und Textauswahl.adoc
@@ -16,7 +16,7 @@ sein.
 == Wie wird geprüft?
 
 * Wird die Fokusposition vom Screenreader ausgegeben?
-* Unterstützt der Inhalt, soweit verfügbar, die vom System und Screenreader vorgesehenen mechanismen der Textauswahl (Ansage der Position Texteinfügemarke, Ansage markierter Text)?
+* Unterstützt der Inhalt, soweit verfügbar, die vom System und Screenreader vorgesehenen Mechanismen der Textauswahl (Ansage der Position Texteinfügemarke, Ansage markierter Text)?
 
 == Quellen
 

--- a/Prüfschritte/de/11.5.2.13 Fokusverfolgung Texteinfügemarke und Textauswahl.adoc
+++ b/Prüfschritte/de/11.5.2.13 Fokusverfolgung Texteinfügemarke und Textauswahl.adoc
@@ -16,8 +16,7 @@ sein.
 == Wie wird geprüft?
 
 * Wird die Fokusposition vom Screenreader ausgegeben?
-* Wird die Position der Texteinfügemarke vom Screenreader ausgegeben?
-* Gibt der Screenreader bei markiertem Text aus, welcher Text markiert ist?
+* Unterstützt der Inhalt, soweit verfügbar, die vom System und Screenreader vorgesehenen mechanismen der Textauswahl (Ansage der Position Texteinfügemarke, Ansage markierter Text)?
 
 == Quellen
 

--- a/Prüfschritte/de/11.5.2.13 Fokusverfolgung Texteinfügemarke und Textauswahl.adoc
+++ b/Prüfschritte/de/11.5.2.13 Fokusverfolgung Texteinfügemarke und Textauswahl.adoc
@@ -15,10 +15,22 @@ sein.
 
 == Wie wird geprüft?
 
-* Wird die Fokusposition vom Screenreader ausgegeben?
+* Wird die Fokusposition innerhalb des Formularfelds vom Screenreader ausgegeben?
 * Unterstützt der Inhalt, soweit verfügbar, die vom System und Screenreader vorgesehenen Mechanismen der Textauswahl (Ansage der Position Texteinfügemarke, Ansage markierter Text)?
 
+== Hinweise
+Die Textauswahl kann je nach Screenreader und Betriebssystem unterschiedlich sein.
+
+=== Android / TalkBack
+
+* Der Bearbeitungsmodus wird durch 2-Finger-Doppeltippen und Halten aktiviert.
+* Die Fokusposition wird in der Regel mit den Lautstärketasten des Geräts versetzt.
+* Über das lokale Kontextmenü (Wischen nach oben und dann nach rechts) können Optionen zum Textauswahl-Modus, zum Kopieren usw. aufgerufen werden
+
 == Quellen
+* https://support.google.com/accessibility/android/answer/6151827?hl=en#zippy=%2Cversion-up%2Cversion-lower[Google-Hilfe zu TalkBack-Gesten]
+* https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-talkback.html[BBC Accessibility and Testing with TalkBack]
+* https://seeingdifferentuk.blogspot.com/2015/06/selecting-copying-and-pasting-with.html[Blogbeitrag SeeingDifferent zu Auswahl, Kopieren, Einfügen mit VoiceOver in iOS]
 
 === Auszug EN 301 549
 

--- a/Prüfschritte/de/11.5.2.13 Fokusverfolgung Texteinfügemarke und Textauswahl.adoc
+++ b/Prüfschritte/de/11.5.2.13 Fokusverfolgung Texteinfügemarke und Textauswahl.adoc
@@ -9,17 +9,15 @@ Dieser Prüfschritt basiert auf den Kriterien der EN 301 549 Abschnitt
 
 == Was wird geprüft?
 
-Informationen und Mechanismen für die Fokusverfolgung, Einfügemarke und
+Informationen und Mechanismen für die Fokusverfolgung, Texteinfügemarke und
 Textauswahl müssen für die Hilfsmitteltechnologie programatisch verfügbar
 sein.
 
 == Wie wird geprüft?
 
-* Kann Text mittels Screenreader navigiert werden?
-* Kann die Einfügemarke bzw. der Cursor versetzt werden und ist dies mit dem
-  Screenreader nachvollziehbar?
-* Kann Text ausgewählt werden und ist dies auch mittels Hilfstechnologie
-  möglich?
+* Wird die Fokusposition vom Screenreader ausgegeben?
+* Wird die Position der Texteinfügemarke vom Screenreader ausgegeben?
+* Gibt der Screenreader bei markiertem Text aus, welcher Text markiert ist?
 
 == Quellen
 

--- a/Prüfschritte/de/11.5.2.13 Fokusverfolgung Texteinfügemarke und Textauswahl.adoc
+++ b/Prüfschritte/de/11.5.2.13 Fokusverfolgung Texteinfügemarke und Textauswahl.adoc
@@ -16,10 +16,10 @@ sein.
 == Wie wird geprüft?
 
 * Wird die Fokusposition innerhalb des Formularfelds vom Screenreader ausgegeben?
-* Unterstützt der Inhalt, soweit verfügbar, die vom System und Screenreader vorgesehenen Mechanismen der Textauswahl (Ansage der Position Texteinfügemarke, Ansage markierter Text)?
+* Unterstützt der Inhalt, soweit verfügbar, die vom System und Screenreader vorgesehenen Mechanismen der Textauswahl hinsichtlich der Ansage (an welcher Position befindet sich die Texteinfügemarke, welcher Text ist markiert)?
 
 == Hinweise
-Die Textauswahl kann je nach Screenreader und Betriebssystem unterschiedlich sein.
+Die Textauswahl kann je nach Screenreader und Betriebssystem unterschiedlich sein. In diesem Prüfschritt geht es darum, dass die aktuelle Position des Fokus vom Screenreader augegeben werden kann und dass der gerade markierte Text ausgegeben werden kann. In 11.5.2.14 wird dagegen bewertet, ob die Position des Fokus und die Markierung des Texts geändert werden kann.
 
 === Android / TalkBack
 

--- a/Prüfschritte/de/11.5.2.14 Programmatisch steuerbare Texteinfügemarke und Selektion.adoc
+++ b/Prüfschritte/de/11.5.2.14 Programmatisch steuerbare Texteinfügemarke und Selektion.adoc
@@ -17,22 +17,23 @@ Hierzu ist es erforderlich, dass diese Aktionen auch programmatisch, also z. B. 
 
 === 1. Anwendbarkeit des Prüfschritts
 
-Der Prüfschritt ist anwendbar, wenn in der App-Ansicht die Texteinfügemarke (Fokus) versetzt werden kann, zum Beispiel in einem Eingabefeld.
+Der Prüfschritt ist anwendbar, wenn in der App-Ansicht die Texteinfügemarke und/oder der Fokus versetzt werden kann, zum Beispiel in einem Eingabefeld.
 Weiterhin ist der Prüfschritt anwendbar, wenn Text markiert werden kann.
 
 === 2. Prüfung
 
 
-. prüfen, ob es Bedienelemente gibt, bei denen sich die Texteinfügemarke bzw. der Fokus versetzen lässt
-. prüfen, ob sich Text auf der Ansicht markieren lässt
+. Prüfen, ob es Bedienelemente/Bereiche gibt, bei denen sich die Texteinfügemarke bzw. der Fokus versetzen lässt
+. Prüfen, ob sich Text auf der Ansicht markieren lässt
 . Screenreader starten
-. prüfen, ob die Aktionen auch mit aktiviertem Screenreader ausführbar sind
+. Prüfen, ob die Aktionen auch mit aktiviertem Screenreader ausführbar sind
 
 === 4. Bewertung
 
 ==== Erfüllt:
 
-* Eingabefeld vorhanden, der Fokus lässt sich mit aktiviertem Screenreader versetzen, auch Text lässt sich markieren
+* Eingabefeld vorhanden, die Texteinfügemarke lässt sich mit aktiviertem Screenreader versetzen und Text lässt sich markieren
+* Fokus zwischen Bedienelementen lässt sich mit aktiviertem Screenreader versetzen
 
 == Einordnung des Prüfschritts
 

--- a/Prüfschritte/de/11.5.2.14 Programmatisch steuerbare Texteinfügemarke und Selektion.adoc
+++ b/Prüfschritte/de/11.5.2.14 Programmatisch steuerbare Texteinfügemarke und Selektion.adoc
@@ -28,6 +28,17 @@ Weiterhin ist der Prüfschritt anwendbar, wenn Text markiert werden kann.
 . Screenreader starten
 . Prüfen, ob die Aktionen auch mit aktiviertem Screenreader ausführbar sind
 
+
+== 3. Hinweise
+
+Die Textauswahl kann je nach Screenreader und Betriebssystem unterschiedlich sein. In diesem Prüfschritt geht es darum, dass die Position des Fokus und die Markierung des Texts geändert werden kann. In 11.5.2.13 wird dagegen bewertet, ob die aktuelle Position des Fokus vom Screenreader augegeben werden kann und dass der gerade markierte Text ausgegeben werden kann.
+
+=== Android / TalkBack
+
+* Der Bearbeitungsmodus wird durch 2-Finger-Doppeltippen und Halten aktiviert.
+* Die Fokusposition wird in der Regel mit den Lautstärketasten des Geräts versetzt.
+* Über das lokale Kontextmenü (Wischen nach oben und dann nach rechts) können Optionen zum Textauswahl-Modus, zum Kopieren usw. aufgerufen werden
+
 === 4. Bewertung
 
 ==== Erfüllt:
@@ -42,6 +53,9 @@ Weiterhin ist der Prüfschritt anwendbar, wenn Text markiert werden kann.
 11.5.2.14 Modification of focus and selection attributes
 
 == Quellen
+* https://support.google.com/accessibility/android/answer/6151827?hl=en#zippy=%2Cversion-up%2Cversion-lower[Google-Hilfe zu TalkBack-Gesten]
+* https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-talkback.html[BBC Accessibility and Testing with TalkBack]
+* https://seeingdifferentuk.blogspot.com/2015/06/selecting-copying-and-pasting-with.html[Blogbeitrag SeeingDifferent zu Auswahl, Kopieren, Einfügen mit VoiceOver in iOS]
 
 [.BLOCK_LANG_EN]
 === 11.5.2.14 Modification of focus and selection attributes


### PR DESCRIPTION
11.5.2.13: Abschnitt "Wie wird geprüft" angepasst dahingehend, dass die Ausgabe des vorliegenden Zustands von Fokus, Texteinfügemarke, Textmarkierung ausgegeben werden muss (geprüft wird nicht, ob die Änderung möglich ist, das wird in 11.5.2.14 geprüft).

11.5.2.14: Ergänzt bzw. etwas deutlicher gemacht, dass der Fokus zwischen Bedienelementen versetzt werden können muss, nicht nur innerhalb eines Eingabefelds