### PR TITLE
Update 11.5.2.10 Textinhalte und –Attribute zugänglich.adoc

### DIFF
--- a/Prüfschritte/de/11.5.2.10 Textinhalte und –Attribute zugänglich.adoc
+++ b/Prüfschritte/de/11.5.2.10 Textinhalte und –Attribute zugänglich.adoc
@@ -22,7 +22,7 @@ Außerdem müssen Screenreader-Nutzer herausfinden können, welche Informationen
 . Auf Geräten mit Touch-Display können die sichtbaren Txtinhalte angetippt werden, die Ausgabe des Screenreaders sollte den sichtbaren Textinhalt enthalten. 
 
 === Prüfung Textauszeichnung
-- Falls die Software Möglichkeiten bietet beim Editieren von Text Attriute zu ändern (z.B. Tet zu fetten oder zu unterstreichen) prüfen, ob es  Möglichkeiten gibt, diese Textattribute mittels Screenreader zu setzen und auszulesen. Dies ist meist nur bei Textbearbeitungsprogrammen der Fall. 
+Falls die Software Möglichkeiten bietet beim Editieren von Text Attriute zu ändern (z.B. Tet zu fetten oder zu unterstreichen) prüfen, ob es  Möglichkeiten gibt, diese Textattribute mittels Screenreader zu setzen und auszulesen. Dies ist meist nur bei Textbearbeitungsprogrammen der Fall. 
 
 ==== Prüfung in iOS / VoiceOver
 

--- a/Prüfschritte/de/11.5.2.10 Textinhalte und –Attribute zugänglich.adoc
+++ b/Prüfschritte/de/11.5.2.10 Textinhalte und –Attribute zugänglich.adoc
@@ -8,29 +8,31 @@ Dieser Prüfschritt basiert auf dem Kriterium 11.5.2.10 Text der EN 301 549.
 
 == Was wird geprüft?
 
-Textinhalte in der Software sind generell für den Screenreader zugänglich.
-Textattribute sind verfügbar, wenn dies generell von der Software
-vorgesehen ist.
-Beispiele für Textattribute sind fett, kursiv oder unterstrichen.
-In einer Textverarbeitung müssen diese Attribute z. B. auch für den
-Screenreader-Nutzer ausgegeben werden können.
+Textinhalte in der Software sind generell für den Screenreader zugänglich. Textattribute sind verfügbar, wenn dies generell von der Software vorgesehen ist.
+Beispiele für Textattribute sind fett, kursiv oder unterstrichen. In einer Textverarbeitung müssen diese Attribute z. B. auch für den Screenreader-Nutzer ausgegeben werden können.
 
-Außerdem muss Der Screenreader-Nutzer herausfinden können, welche
-Informationen gerade auf dem Display angezeigt werden (Viewport).
+Außerdem muss Der Screenreader-Nutzer herausfinden können, welche Informationen gerade auf dem Display angezeigt werden (Viewport).
 
 == Wie wird geprüft?
+=== Prüfung Textausgabe
 
-Mit dem Screenreader die Software navigieren und prüfen, ob alle sichtbaren
-Texte auch von der Hilfsmittel-Software erkannt werden.
+. Screenreader aktivieren
+. Vom Beginn der Ansicht bis zum Ende alle Textinhalte  mit Wischgesten durchaufen
+. Prüfen, ob alle sichtbaren Elemente auch vom Screenreader ausgegeben werden
+. Auf Geräten mit Touch-Display können die sichtbaren Txtinhalte angetippt werden, die Ausgabe des Screenreaders sollte den sichtbaren Textinhalt enthalten. 
 
-Dabei wird mit eingeschaltetem SR überprüft, ob die Sichtbaren Elemente auch
-vom Screenreader ausgegeben werden.
-Auf Geräten mit Touch-Display können die Sichtbaren Elemente angetippt
-werden, die Ausgabe vom SR sollte dann mit dem zu sehenden Element
-übereinstimmen.
+=== Prüfung Textauszeichnung
+- Falls die Software Möglichkeiten bietet beim Editieren von Text Attriute zu ändern (z.B. Tet zu fetten oder zu unterstreichen) prüfen, ob es  Möglichkeiten gibt, diese Textattribute mittels Screenreader zu setzen und auszulesen. Dies ist meist nur bei Textbearbeitungsprogrammen der Fall. 
 
-Prüfen, ob es auch Möglichkeiten gibt, Textattribute mittels Screenreader
-anzuzeigen, wenn dies von der Software generell angeboten wird.
+==== Prüfung in iOS / VoiceOver
+
+. Gibt es editierbaren Text? Falls ja:
+.. Über Rotor-Option 'Textauswahl' über horizontale Wischgeste einen kleinen Textbereich mit gesetztem Textattribut (etwa Fettung) auswählen
+.. Im Rotor schauen, ob die Option "Aktionen" und darin (vertikale Wischgeste) die Option "Textformat" verfügbar ist.  Diese durch Doppeltippen aufrufen.
+.. Gesetztes Textformat auswählen, prüfen, ob es sich ändern lässt (z.B. über VoiceOver die Auswahl "fett" für den ausgewählten Text entfernen und wieder setzen). 
+. Falls nein, Prüfung abbrechen.
+
+==== Prüfung in Android
 
 == Quellen
 

--- a/Prüfschritte/de/11.5.2.10 Textinhalte und –Attribute zugänglich.adoc
+++ b/Prüfschritte/de/11.5.2.10 Textinhalte und –Attribute zugänglich.adoc
@@ -8,30 +8,41 @@ Dieser Prüfschritt basiert auf dem Kriterium 11.5.2.10 Text der EN 301 549.
 
 == Was wird geprüft?
 
-Textinhalte in der Software sind generell für den Screenreader zugänglich. Textattribute sind verfügbar, wenn dies generell von der Software vorgesehen ist.
-Beispiele für Textattribute sind fett, kursiv oder unterstrichen. In einer Textverarbeitung müssen diese Attribute z. B. auch für den Screenreader-Nutzer ausgegeben werden können.
+Wenn eine App Text enthält, soll der Text für Screenreader-Nutzer zugänglich sein. Wenn Apps die Bearbeitung von Text bieten und die Auszeichnung von Texten unterstützen (etwa die Setzung der Textattribute fett oder kursiv), sollen diese Textattribute auch für Hilfsmittelnutzende verfügbar sein.
 
-Außerdem müssen Screenreader-Nutzer herausfinden können, welche Informationen gerade auf dem Display angezeigt werden (Viewport).
+Außerdem müssen Screenreader-Nutzende herausfinden können, welche Informationen gerade auf dem Display angezeigt werden (Viewport).
+
+== Warum wird das geprüft? 
+
+Texte in einer App müssen nicht nur sichtbar, sondern auch für Hilfsmittel-Nutzende zugänglich sein. Werden von einer App Möglichkeiten der Textverabeitung geboten, sollen  Hilfsmittel-Nutzende Textattribute erkennen, also auslesen können.
 
 == Wie wird geprüft?
-=== Prüfung Textausgabe
+
+=== 1. Anwendbarkeit des Prüfschritts
+
+Der Prüfschritt ist anwendbar, wenn Apps Texte enthalten. Die zusätzliche Prüfung der Textauszeichnung ist anwendbar, wenn Apps Textbearbeitungsfunktionen bieten.
+
+=== 2. Prüfung
+
+==== 2.1 Prüfung der Textausgabe
 
 . Screenreader aktivieren
-. Vom Beginn der Ansicht bis zum Ende alle Textinhalte  mit Wischgesten durchlaufen
+. Vom Beginn der Ansicht bis zum Ende alle editierbaren Textinhalte  mit Wischgesten durchlaufen
 . Prüfen, ob alle sichtbaren Elemente auch vom Screenreader ausgegeben werden
 . Auf Geräten mit Touch-Display können die sichtbaren Textinhalte angetippt werden, die Ausgabe des Screenreaders sollte den sichtbaren Textinhalt enthalten. 
 
-=== Prüfung Textauszeichnung
-Falls die Software Möglichkeiten bietet, beim Editieren von Text Attribute zu ändern (z.B. Text zu fetten oder zu unterstreichen) prüfen, ob es Möglichkeiten gibt, diese Textattribute mittels Screenreader auszulesen. Dies ist meist nur bei Textbearbeitungsprogrammen der Fall. 
+==== 2.2 Prüfung der Textauszeichnung
 
-==== Prüfung in iOS / VoiceOver
+Falls die Software grundsätzlich Möglichkeiten bietet, Text-Attribute zu ändern (z.B. Text zu fetten, kursiv zu setzen oder zu unterstreichen) prüfen, ob es Möglichkeiten gibt, diese Textattribute mittels Screenreader auszulesen. Dies ist meist nur bei Textbearbeitungsprogrammen der Fall. 
+
+===== Prüfung der Textauszeichnung in iOS / VoiceOver
 . Gibt es editierbaren Text? Falls ja:
 .. Über Rotor-Option 'Textauswahl' über horizontale Wischgeste einen kleinen Textbereich mit gesetztem Textattribut (etwa Fettung) auswählen
 .. Im Rotor schauen, ob die Option "Aktionen" und darin (vertikale Wischgeste) die Option "Textformat" verfügbar ist.  Diese durch Doppeltippen aufrufen.
 .. Gesetztes Textformat auswählen, ggf. zusätzlich prüfen, ob es sich ändern lässt (z.B. über VoiceOver die Auswahl "fett" für den ausgewählten Text entfernen und wieder setzen). 
 . Falls nein, Prüfung abbrechen.
 
-==== Prüfung in Android
+===== Prüfung Textauszeichnung in Android
 . Gibt es editierbaren Text? Falls ja:
 .. Auswählen: "Talkback-Menü" (Wischgeste nach oben und rechts)  > "Bearbeitungsoptionen" > "Auswahlmodus starten oder beenden"
 .. Mit vertikalen Wischgesten Text auswählen

--- a/Prüfschritte/de/11.5.2.10 Textinhalte und –Attribute zugänglich.adoc
+++ b/Prüfschritte/de/11.5.2.10 Textinhalte und –Attribute zugänglich.adoc
@@ -36,7 +36,7 @@ Falls die Software Möglichkeiten bietet, beim Editieren von Text Attribute zu �
 .. Auswählen: "Talkback-Menü" (Wischgeste nach oben und rechts)  > "Bearbeitungsoptionen" > "Auswahlmodus starten oder beenden"
 .. Mit vertikalen Wischgesten Text auswählen
 .. Wenn in der Software vorhanden, Bedienelement für Textauszeichnung fokussieren (etwa "B" für "fett") und überprüfen, ob der Zustand richtig ausgegeben wird 
-.. Über Talkback-Menü > Aktionen > "Formatierung der aktuellen Auswahl vorlesen" prüfen ob der Stil des Textes korrekt ausgggeben wird
+.. Über Talkback-Menü > Aktionen > "Formatierung der aktuellen Auswahl vorlesen" prüfen, ob der Stil des Textes korrekt ausgggeben wird
 . Falls nein, Prüfung abbrechen.
 
 == Quellen

--- a/Prüfschritte/de/11.5.2.10 Textinhalte und –Attribute zugänglich.adoc
+++ b/Prüfschritte/de/11.5.2.10 Textinhalte und –Attribute zugänglich.adoc
@@ -17,9 +17,9 @@ Außerdem müssen Screenreader-Nutzer herausfinden können, welche Informationen
 === Prüfung Textausgabe
 
 . Screenreader aktivieren
-. Vom Beginn der Ansicht bis zum Ende alle Textinhalte  mit Wischgesten durchaufen
+. Vom Beginn der Ansicht bis zum Ende alle Textinhalte  mit Wischgesten durchlaufen
 . Prüfen, ob alle sichtbaren Elemente auch vom Screenreader ausgegeben werden
-. Auf Geräten mit Touch-Display können die sichtbaren Txtinhalte angetippt werden, die Ausgabe des Screenreaders sollte den sichtbaren Textinhalt enthalten. 
+. Auf Geräten mit Touch-Display können die sichtbaren Textinhalte angetippt werden, die Ausgabe des Screenreaders sollte den sichtbaren Textinhalt enthalten. 
 
 === Prüfung Textauszeichnung
 Falls die Software Möglichkeiten bietet, beim Editieren von Text Attribute zu ändern (z.B. Text zu fetten oder zu unterstreichen) prüfen, ob es Möglichkeiten gibt, diese Textattribute mittels Screenreader auszulesen. Dies ist meist nur bei Textbearbeitungsprogrammen der Fall. 

--- a/Prüfschritte/de/11.5.2.10 Textinhalte und –Attribute zugänglich.adoc
+++ b/Prüfschritte/de/11.5.2.10 Textinhalte und –Attribute zugänglich.adoc
@@ -11,7 +11,7 @@ Dieser Prüfschritt basiert auf dem Kriterium 11.5.2.10 Text der EN 301 549.
 Textinhalte in der Software sind generell für den Screenreader zugänglich. Textattribute sind verfügbar, wenn dies generell von der Software vorgesehen ist.
 Beispiele für Textattribute sind fett, kursiv oder unterstrichen. In einer Textverarbeitung müssen diese Attribute z. B. auch für den Screenreader-Nutzer ausgegeben werden können.
 
-Außerdem muss Der Screenreader-Nutzer herausfinden können, welche Informationen gerade auf dem Display angezeigt werden (Viewport).
+Außerdem müssen Screenreader-Nutzer herausfinden können, welche Informationen gerade auf dem Display angezeigt werden (Viewport).
 
 == Wie wird geprüft?
 === Prüfung Textausgabe
@@ -33,6 +33,8 @@ Außerdem muss Der Screenreader-Nutzer herausfinden können, welche Informatione
 . Falls nein, Prüfung abbrechen.
 
 ==== Prüfung in Android
+
+(folgt)
 
 == Quellen
 

--- a/Prüfschritte/de/11.5.2.10 Textinhalte und –Attribute zugänglich.adoc
+++ b/Prüfschritte/de/11.5.2.10 Textinhalte und –Attribute zugänglich.adoc
@@ -22,21 +22,21 @@ Außerdem müssen Screenreader-Nutzer herausfinden können, welche Informationen
 . Auf Geräten mit Touch-Display können die sichtbaren Txtinhalte angetippt werden, die Ausgabe des Screenreaders sollte den sichtbaren Textinhalt enthalten. 
 
 === Prüfung Textauszeichnung
-Falls die Software Möglichkeiten bietet beim Editieren von Text Attriute zu ändern (z.B. Tet zu fetten oder zu unterstreichen) prüfen, ob es  Möglichkeiten gibt, diese Textattribute mittels Screenreader zu setzen und auszulesen. Dies ist meist nur bei Textbearbeitungsprogrammen der Fall. 
+Falls die Software Möglichkeiten bietet, beim Editieren von Text Attribute zu ändern (z.B. Text zu fetten oder zu unterstreichen) prüfen, ob es Möglichkeiten gibt, diese Textattribute mittels Screenreader auszulesen. Dies ist meist nur bei Textbearbeitungsprogrammen der Fall. 
 
 ==== Prüfung in iOS / VoiceOver
 . Gibt es editierbaren Text? Falls ja:
 .. Über Rotor-Option 'Textauswahl' über horizontale Wischgeste einen kleinen Textbereich mit gesetztem Textattribut (etwa Fettung) auswählen
 .. Im Rotor schauen, ob die Option "Aktionen" und darin (vertikale Wischgeste) die Option "Textformat" verfügbar ist.  Diese durch Doppeltippen aufrufen.
-.. Gesetztes Textformat auswählen, prüfen, ob es sich ändern lässt (z.B. über VoiceOver die Auswahl "fett" für den ausgewählten Text entfernen und wieder setzen). 
+.. Gesetztes Textformat auswählen, ggf. zusätzlich prüfen, ob es sich ändern lässt (z.B. über VoiceOver die Auswahl "fett" für den ausgewählten Text entfernen und wieder setzen). 
 . Falls nein, Prüfung abbrechen.
 
 ==== Prüfung in Android
 . Gibt es editierbaren Text? Falls ja:
 .. Auswählen: "Talkback-Menü" (Wischgeste nach oben und rechts)  > "Bearbeitungsoptionen" > "Auswahlmodus starten oder beenden"
 .. Mit vertikalen Wischgesten Text auswählen
-.. Wenn in der Software vorhanden, Bedienelement zum Ändern einer Textauszeichnung aktvieren, etwa "B" für "fett"
-.. Prüfen, ob der Stil angewandt wird und sich über Talkback-Menü > Aktionen > "Formatierung der aktuellen Auswahl vorlesen" korrekt ausgeben lässt
+.. Wenn in der Software vorhanden, Bedienelement für Textauszeichnung fokussieren (etwa "B" für "fett") und überprüfen, ob der Zustand richtig ausgegeben wird 
+.. Über Talkback-Menü > Aktionen > "Formatierung der aktuellen Auswahl vorlesen" prüfen ob der Stil des Textes korrekt ausgggeben wird
 . Falls nein, Prüfung abbrechen.
 
 == Quellen

--- a/Prüfschritte/de/11.5.2.10 Textinhalte und –Attribute zugänglich.adoc
+++ b/Prüfschritte/de/11.5.2.10 Textinhalte und –Attribute zugänglich.adoc
@@ -4,7 +4,7 @@ include::include/attributes.adoc[]
 
 == Was wird geprüft?
 
-Wenn eine App Text enthält, soll der Text für Screenreader-Nutzer zugänglich sein. Wenn Apps die Bearbeitung von Text bieten und die Auszeichnung von Texten unterstützen (etwa die Setzung der Textattribute fett oder kursiv), sollen diese Textattribute auch für Hilfsmittelnutzende verfügbar sein.
+Wenn eine App Text enthält, soll der Text für Screenreader-Nutzende zugänglich sein. Wenn Apps die Bearbeitung von Text bieten und die Auszeichnung von Texten unterstützen (etwa die Setzung der Textattribute fett oder kursiv), sollen diese Textattribute auch für Hilfsmittelnutzende verfügbar sein.
 
 Außerdem müssen Screenreader-Nutzende herausfinden können, welche Informationen gerade auf dem Display angezeigt werden (Viewport).
 
@@ -33,7 +33,7 @@ Falls die Software grundsätzlich Möglichkeiten bietet, Text-Attribute zu ände
 
 ===== Prüfung der Textauszeichnung in iOS / VoiceOver
 . Gibt es editierbaren Text? Falls ja:
-.. Über Rotor-Option 'Textauswahl' über horizontale Wischgeste einen kleinen Textbereich mit gesetztem Textattribut (etwa Fettung) auswählen
+.. Über Rotor-Option 'Textauswahl' über horizontale Wischgeste einen kleinen Textbereich mit gesetztem Textattribut (etwa Fettung) auswählen.
 .. Im Rotor schauen, ob die Option "Aktionen" und darin (vertikale Wischgeste) die Option "Textformat" verfügbar ist.  Diese durch Doppeltippen aufrufen.
 .. Gesetztes Textformat auswählen, ggf. zusätzlich prüfen, ob es sich ändern lässt (z.B. über VoiceOver die Auswahl "fett" für den ausgewählten Text entfernen und wieder setzen). 
 . Falls nein, Prüfung abbrechen.
@@ -41,9 +41,9 @@ Falls die Software grundsätzlich Möglichkeiten bietet, Text-Attribute zu ände
 ===== Prüfung Textauszeichnung in Android
 . Gibt es editierbaren Text? Falls ja:
 .. Auswählen: "Talkback-Menü" (Wischgeste nach oben und rechts)  > "Bearbeitungsoptionen" > "Auswahlmodus starten oder beenden"
-.. Mit vertikalen Wischgesten Text auswählen
-.. Wenn in der Software vorhanden, Bedienelement für Textauszeichnung fokussieren (etwa "B" für "fett") und überprüfen, ob der Zustand richtig ausgegeben wird 
-.. Über Talkback-Menü > Aktionen > "Formatierung der aktuellen Auswahl vorlesen" prüfen, ob der Stil des Textes korrekt ausgggeben wird
+.. Mit vertikalen Wischgesten Text auswählen.
+.. Wenn in der Software vorhanden, Bedienelement für Textauszeichnung fokussieren (etwa "B" für "fett") und überprüfen, ob der Zustand richtig ausgegeben wird. 
+.. Über Talkback-Menü > Aktionen > "Formatierung der aktuellen Auswahl vorlesen" prüfen, ob der Stil des Textes korrekt ausgggeben wird.
 . Falls nein, Prüfung abbrechen.
 
 == Quellen

--- a/Prüfschritte/de/11.5.2.10 Textinhalte und –Attribute zugänglich.adoc
+++ b/Prüfschritte/de/11.5.2.10 Textinhalte und –Attribute zugänglich.adoc
@@ -35,7 +35,7 @@ Falls die Software Möglichkeiten bietet beim Editieren von Text Attriute zu än
 . Gibt es editierbaren Text? Falls ja:
 .. Auswählen: "Talkback-Menü" (Wischgeste nach oben und rechts)  > "Bearbeitungsoptionen" > "Auswahlmodus starten oder beenden"
 .. Mit vertikalen Wischgesten Text auswählen
-.. Wenn in der Software vorhanden, Bedienelement zum Ändern einer Auszeichnugn aktvieren, etwa "B" für "fett"
+.. Wenn in der Software vorhanden, Bedienelement zum Ändern einer Textauszeichnung aktvieren, etwa "B" für "fett"
 .. Prüfen, ob der Stil angewandt wird und sich über Talkback-Menü > Aktionen > "Formatierung der aktuellen Auswahl vorlesen" korrekt ausgeben lässt
 . Falls nein, Prüfung abbrechen.
 

--- a/Prüfschritte/de/11.5.2.10 Textinhalte und –Attribute zugänglich.adoc
+++ b/Prüfschritte/de/11.5.2.10 Textinhalte und –Attribute zugänglich.adoc
@@ -32,8 +32,12 @@ Falls die Software Möglichkeiten bietet beim Editieren von Text Attriute zu än
 . Falls nein, Prüfung abbrechen.
 
 ==== Prüfung in Android
-
-(folgt)
+. Gibt es editierbaren Text? Falls ja:
+.. Auswählen: "Talkback-Menü" (Wischgeste nach oben und rechts)  > "Bearbeitungsoptionen" > "Auswahlmodus starten oder beenden"
+.. Mit vertikalen Wischgesten Text auswählen
+.. Wenn in der Software vorhanden, Bedienelement zum Ändern einer Auszeichnugn aktvieren, etwa "B" für "fett"
+.. Prüfen, ob der Stil angewandt wird und sich über Talkback-Menü > Aktionen > "Formatierung der aktuellen Auswahl vorlesen" korrekt ausgeben lässt
+. Falls nein, Prüfung abbrechen.
 
 == Quellen
 

--- a/Prüfschritte/de/11.5.2.10 Textinhalte und –Attribute zugänglich.adoc
+++ b/Prüfschritte/de/11.5.2.10 Textinhalte und –Attribute zugänglich.adoc
@@ -2,10 +2,6 @@
 include::include/author.adoc[]
 include::include/attributes.adoc[]
 
-== Grundlage des Prüfschritts
-
-Dieser Prüfschritt basiert auf dem Kriterium 11.5.2.10 Text der EN 301 549.
-
 == Was wird geprüft?
 
 Wenn eine App Text enthält, soll der Text für Screenreader-Nutzer zugänglich sein. Wenn Apps die Bearbeitung von Text bieten und die Auszeichnung von Texten unterstützen (etwa die Setzung der Textattribute fett oder kursiv), sollen diese Textattribute auch für Hilfsmittelnutzende verfügbar sein.

--- a/Prüfschritte/de/11.5.2.10 Textinhalte und –Attribute zugänglich.adoc
+++ b/Prüfschritte/de/11.5.2.10 Textinhalte und –Attribute zugänglich.adoc
@@ -25,7 +25,6 @@ Außerdem müssen Screenreader-Nutzer herausfinden können, welche Informationen
 Falls die Software Möglichkeiten bietet beim Editieren von Text Attriute zu ändern (z.B. Tet zu fetten oder zu unterstreichen) prüfen, ob es  Möglichkeiten gibt, diese Textattribute mittels Screenreader zu setzen und auszulesen. Dies ist meist nur bei Textbearbeitungsprogrammen der Fall. 
 
 ==== Prüfung in iOS / VoiceOver
-
 . Gibt es editierbaren Text? Falls ja:
 .. Über Rotor-Option 'Textauswahl' über horizontale Wischgeste einen kleinen Textbereich mit gesetztem Textattribut (etwa Fettung) auswählen
 .. Im Rotor schauen, ob die Option "Aktionen" und darin (vertikale Wischgeste) die Option "Textformat" verfügbar ist.  Diese durch Doppeltippen aufrufen.


### PR DESCRIPTION
Prüfung iOS für Textformate hinzugefügt.
Wird nur selten (bei Textverarbeitungen) anzuwenden sein.  Bei Markdown-Editoren kann die ASCII Formatierung ausglesen werden etwa dies ist **fetter** Text)

Ich bin mir nicht sicher, ob diese recht aufwändige Prüfung außer bei Anwendungen, die das Editieren von Text ermöglichen (Google Docs App, Microsoft Word App. Pages App) überhaupt sinnvoll ist. Es ist (nach informellen Tests mehrerer Apps auf Ausgabemöglichkeiten) zu vermuten, dass das Textformat bei statischen Texten i.d.R. **nicht** für Screenreader verfügbar ist. Bedeutet das, das jedwedes Vorkommen von Fettung, Unterstreichung kursiv usw. in statischen Texten zu einem FAIL in diesem Prüfschritt führen müsste? 
Die Beschränkung auf die Ausgabe von Textattributen bei **Textverarbeitungen** (etwa Office Apps) scheint realistisch. Dennoch ist unklar, ob hier die Latte nicht doch eigentlich höher gehängt ist.