### PR TITLE
12.1.1-Neuformulierung-Prüfanleitung

### DIFF
--- a/Prüfschritte/de/12.1.1 Dokumentation von Kompatibilität und Barrierefreiheit.adoc
+++ b/Prüfschritte/de/12.1.1 Dokumentation von Kompatibilität und Barrierefreiheit.adoc
@@ -11,51 +11,35 @@ In dieser Tabelle wird auf Abschnitt
 
 == Was wird geprüft?
 
-Die Dokumentation der Software soll die Eigenschaften und Funktionen in  Bezug
-auf Barrierefreiheit auflisten undessen Nutzung erklären.
-Dazu zählen auch Informationen zur Kompatibilität mit assistiven Technologien.
+Die Dokumentation der App soll, wenn vorhanden, besondere Eigenschaften und Funktionen in Bezug auf Barrierefreiheit auflisten und deren Nutzung erklären. Dazu zählen auch Informationen zur Kompatibilität mit assistiven Technologien.
+
+== Warum wird das geprüft? 
 
 == Wie wird geprüft?
 
-=== Anwendbarkeit des Prüfschritts
+=== 1. Anwendbarkeit des Prüfschritts
 
-Dieser Prüfschritt ist anwendbar, wenn der Teil der Dokumentation, der sich
-mit Barrierefreiheit und Kompatibilität beschäftigt, in die App integriert
-ist.
-Dokumentation, die ausschließlich außerhalb der App bereitgestellt wird,
-kann nicht im Rahmen dieses Prüfverfahrens mitgetestet werden.
-Die entsprechende Dokumentation muss dann in einem separaten Auftrag geprüft
-werden.
+Dieser Prüfschritt ist anwendbar, wenn es Dokumentation zur Barrierefreiheit und Kompatibilität gibt, und diese Dokumentation in die App integriert ist. Dokumentation, die ausschließlich außerhalb der App bereitgestellt wird, kann nicht im Rahmen dieses Prüfverfahrens mitgetestet werden. Die entsprechende Dokumentation muss dann in einem separaten Auftrag geprüft werden.
 
-=== Prüfung
+=== 2. Prüfung
+
+Wenn es für die Barrierefreiheit relevante Funktionen oder Einstellungsmöglichkeiten gibt, sollen diese in der Dokumentation aufgelistet und erklärt werden. Alle für die Barrierefreiheit relevanten Informationen zur App sollen in der Dokumentation aufgelistet und erklärt werden. Die Dokumentation kann dabei sowohl in die App integriert oder separat verfügbar sein. Zu finden ist solche Dokumentation in der Regel ubnter Einstellungen, auf Hilfeseiten bzw. in Support-Bereichen, Wikis oder in der Erklärung zur Barrierefreiheit. Dazu gehört etwa:
+
+* Barrierefreiheitserklärung nach EU-Richtlinie 2016/2102
+* Einzelheiten zu angebotenen Barrierefreiheits-Einstellungen, sofern diese in der App selbst integriert sind, zum Beispiel:
+** Vorlesefunktion
+** Einstellungsmögliochkeiten für individueller Farbschemata 
+** Besondere Tastaturkürzel oder Gesten für die Nutzung mit assistiven Technologien
+** Hinweise auf unterstützte Umgebungen, falls es Einschränkungen bei der Nutzbarkeit mit assistiven Technologien gibt
+** Deaktivierung von Bewegungen oder automatischem Abspielen von Video- oder Audio-Inhalten
+
+
 
 Für die Prüfpraxis sind weitere Hinweise notwendig, auf GitHub können Sie
 https://github.com/BIK-BITV/BIK-App-Test/issues[dazu ein Issue eröffnen].
 
-Alle für die Barrierefreiheit relevanten Informationen zur Software sollen
-in der Dokumentation aufgelistet und erklärt werden.
-Die Dokumentation kann dabei mit der Software mitgeliefert werden oder separat
-verfügbar sein.
 
-Die Dokumentation kann dabei z. B. folgende Informationen enthalten:
 
-* Barrierefreiheitserklärung nach EU-Richtlinie 2016/2102
-* Einzelheiten zu Features für die Barrierefreiheit
-** Vorlesefunktion
-** Kontrastumschalter / Schalter für Farbschemata / Aktivierung verbesserter
-   Maus-/Tastaturfokus
-** Vergrößerungsfunktion
-** Anpassung von Textabständen
-** Deaktivierung von Bewegungen oder automatischen Audios
-** besondere Bedienungsarten mit Tastatur / Tastenkombinationen
-* Informationen zur Kompatibilität mit assistiven Technologien
-* spezielle Tastenkombinationen für die Nutzung mit assistiven Technologien
-* Verzeichnisse für Abkürzungen
-* Verweise zuHilfeseiten
-
-Die Software soll, wenn möglich, Metadaten für die unterstützten
-Barrierefreiheitsfunktionen und Kompatibilität maschienenlesbar, in geeigneten
-Formaten, bereitstellen.
 
 == Quellen
 

--- a/Prüfschritte/de/12.1.1 Dokumentation von Kompatibilität und Barrierefreiheit.adoc
+++ b/Prüfschritte/de/12.1.1 Dokumentation von Kompatibilität und Barrierefreiheit.adoc
@@ -2,18 +2,13 @@
 include::include/author.adoc[]
 include::include/attributes.adoc[]
 
-== Grundlage des Prüfschritts
-
-Grundlage des Prüfschritts ist die Tabelle A.2 im Annex A der EN 301 549
-V3.1.1.
-In dieser Tabelle wird auf Abschnitt
-12.1.1 "Accessibility and compatibility features" verwiesen.
-
 == Was wird geprüft?
 
-Die Dokumentation der App soll, wenn vorhanden, besondere Eigenschaften und Funktionen in Bezug auf Barrierefreiheit auflisten und deren Nutzung erklären. Dazu zählen auch Informationen zur Kompatibilität mit assistiven Technologien.
+Die Dokumentation der App soll, wenn vorhanden, besondere Eigenschaften und Funktionen in Bezug auf Barrierefreiheit auflisten und deren Nutzung erklären, sofern diese als Teil der App selbst implementiert wurden. Dazu gehören zum Beispiel Vorlesefunktionen, Funktionen zum Einstellen individueller Farbschemata oder verfügbare Tastaturkurzbefehle. Auch Informationen zur (möglicherweise eingeschränkten) Kompatibilität mit assistiven Technologien zählen dazu.
 
 == Warum wird das geprüft? 
+
+Wenn Apps bestimmte Barrierefreiheitsfunktionen enthalten, sollten diese gut dokumentiert sein, denn viele Nutzende werden ohne ausdrückliche Hinweise diese Funktionen nicht erkennen oder nutzen können.
 
 == Wie wird geprüft?
 
@@ -23,7 +18,7 @@ Dieser Prüfschritt ist anwendbar, wenn es Dokumentation zur Barrierefreiheit un
 
 === 2. Prüfung
 
-Wenn es für die Barrierefreiheit relevante Funktionen oder Einstellungsmöglichkeiten gibt, sollen diese in der Dokumentation aufgelistet und erklärt werden. Die Dokumentation kann dabei sowohl in die App integriert oder separat verfügbar sein. Zu finden ist solche Dokumentation in der Regel in den Einstellungen, auf Hilfeseiten bzw. in Support-Bereichen, in Wikis oder in der Erklärung zur Barrierefreiheit. Zu relevanten Funktionen und Einstellungsmöglichkeiten gehören etwa:
+Wenn es für die Barrierefreiheit relevante Funktionen oder Einstellungsmöglichkeiten gibt, sollen diese in der Dokumentation aufgelistet und erklärt werden. Die Dokumentation kann dabei sowohl in die App integriert oder separat verfügbar sein. Zu finden ist eine solche Dokumentation in der Regel in den Einstellungen, auf Hilfeseiten bzw. in Support-Bereichen, in Wikis oder in der Erklärung zur Barrierefreiheit. Zu relevanten Funktionen und Einstellungsmöglichkeiten gehören etwa:
 
 * Barrierefreiheitserklärung nach EU-Richtlinie 2016/2102
 * Einzelheiten zu angebotenen Barrierefreiheits-Einstellungen, sofern diese in der App selbst integriert sind, zum Beispiel:
@@ -32,6 +27,13 @@ Wenn es für die Barrierefreiheit relevante Funktionen oder Einstellungsmöglich
 ** Besondere Tastaturkürzel oder Gesten für die Nutzung mit assistiven Technologien
 ** Hinweise auf unterstützte Umgebungen, falls es Einschränkungen bei der Nutzbarkeit mit assistiven Technologien gibt
 ** Deaktivierung von Bewegungen oder automatischem Abspielen von Video- oder Audio-Inhalten
+
+=== 3. Hinweise
+
+3. Hinweise
+. Das Fehlen von zusätzlichen Barrierefreiheits-Funktionen wird nicht negativ bewertet. Wenn sie eingesetzt werden, müssen sie aber dokumentiert sein.
+
+. Es wird nur die Dokumentation von Barrierefreiheits-Funktionen verlangt, die von der App selbst implementiert werden. Dazu gehören auch Features wie Vorlesefunktionen, die von Drittanbietern definiert und im Angebot eingebunden werden. Barrierefreiheits-Funktionen des jeweiligen Betriebssystems müssen dagegen nicht dokumentiert werden.
 
 Für die Prüfpraxis sind weitere Hinweise notwendig, auf GitHub können Sie
 https://github.com/BIK-BITV/BIK-App-Test/issues[dazu ein Issue eröffnen].

--- a/Prüfschritte/de/12.1.1 Dokumentation von Kompatibilität und Barrierefreiheit.adoc
+++ b/Prüfschritte/de/12.1.1 Dokumentation von Kompatibilität und Barrierefreiheit.adoc
@@ -23,7 +23,7 @@ Dieser Prüfschritt ist anwendbar, wenn es Dokumentation zur Barrierefreiheit un
 
 === 2. Prüfung
 
-Wenn es für die Barrierefreiheit relevante Funktionen oder Einstellungsmöglichkeiten gibt, sollen diese in der Dokumentation aufgelistet und erklärt werden. Alle für die Barrierefreiheit relevanten Informationen zur App sollen in der Dokumentation aufgelistet und erklärt werden. Die Dokumentation kann dabei sowohl in die App integriert oder separat verfügbar sein. Zu finden ist solche Dokumentation in der Regel ubnter Einstellungen, auf Hilfeseiten bzw. in Support-Bereichen, Wikis oder in der Erklärung zur Barrierefreiheit. Dazu gehört etwa:
+Wenn es für die Barrierefreiheit relevante Funktionen oder Einstellungsmöglichkeiten gibt, sollen diese in der Dokumentation aufgelistet und erklärt werden. Die Dokumentation kann dabei sowohl in die App integriert oder separat verfügbar sein. Zu finden ist solche Dokumentation in der Regel ubnter Einstellungen, auf Hilfeseiten bzw. in Support-Bereichen, Wikis oder in der Erklärung zur Barrierefreiheit. Dazu gehört etwa:
 
 * Barrierefreiheitserklärung nach EU-Richtlinie 2016/2102
 * Einzelheiten zu angebotenen Barrierefreiheits-Einstellungen, sofern diese in der App selbst integriert sind, zum Beispiel:

--- a/Prüfschritte/de/12.1.1 Dokumentation von Kompatibilität und Barrierefreiheit.adoc
+++ b/Prüfschritte/de/12.1.1 Dokumentation von Kompatibilität und Barrierefreiheit.adoc
@@ -18,7 +18,7 @@ Dieser Prüfschritt ist anwendbar, wenn es Dokumentation zur Barrierefreiheit un
 
 === 2. Prüfung
 
-Wenn es für die Barrierefreiheit relevante Funktionen oder Einstellungsmöglichkeiten gibt, sollen diese in der Dokumentation aufgelistet und erklärt werden. Die Dokumentation kann dabei sowohl in die App integriert oder separat verfügbar sein. Zu finden ist eine solche Dokumentation in der Regel in den Einstellungen, auf Hilfeseiten bzw. in Support-Bereichen, in Wikis oder in der Erklärung zur Barrierefreiheit. Die Dokumentation muss dabei z. B. folgende Informationen enthalten, sofern relevant::
+Wenn es für die Barrierefreiheit relevante Funktionen oder Einstellungsmöglichkeiten gibt, sollen diese in der Dokumentation aufgelistet und erklärt werden. Die Dokumentation kann dabei sowohl in die App integriert oder separat verfügbar sein. Zu finden ist eine solche Dokumentation in der Regel in den Einstellungen, auf Hilfeseiten bzw. in Support-Bereichen, in Wikis oder in der Erklärung zur Barrierefreiheit. Die Dokumentation muss dabei z. B. folgende Informationen enthalten, sofern relevant:
 
 * Barrierefreiheitserklärung nach EU-Richtlinie 2016/2102 (ggf. verlinkt)
 * Einzelheiten zu angebotenen Barrierefreiheits-Einstellungen, sofern diese in der App selbst integriert sind, zum Beispiel:

--- a/Prüfschritte/de/12.1.1 Dokumentation von Kompatibilität und Barrierefreiheit.adoc
+++ b/Prüfschritte/de/12.1.1 Dokumentation von Kompatibilität und Barrierefreiheit.adoc
@@ -30,7 +30,6 @@ Wenn es für die Barrierefreiheit relevante Funktionen oder Einstellungsmöglich
 
 === 3. Hinweise
 
-3. Hinweise
 . Das Fehlen von zusätzlichen Barrierefreiheits-Funktionen wird nicht negativ bewertet. Wenn sie eingesetzt werden, müssen sie aber dokumentiert sein.
 
 . Es wird nur die Dokumentation von Barrierefreiheits-Funktionen verlangt, die von der App selbst implementiert werden. Dazu gehören auch Features wie Vorlesefunktionen, die von Drittanbietern definiert und im Angebot eingebunden werden. Barrierefreiheits-Funktionen des jeweiligen Betriebssystems müssen dagegen nicht dokumentiert werden.

--- a/Prüfschritte/de/12.1.1 Dokumentation von Kompatibilität und Barrierefreiheit.adoc
+++ b/Prüfschritte/de/12.1.1 Dokumentation von Kompatibilität und Barrierefreiheit.adoc
@@ -18,9 +18,9 @@ Dieser Prüfschritt ist anwendbar, wenn es Dokumentation zur Barrierefreiheit un
 
 === 2. Prüfung
 
-Wenn es für die Barrierefreiheit relevante Funktionen oder Einstellungsmöglichkeiten gibt, sollen diese in der Dokumentation aufgelistet und erklärt werden. Die Dokumentation kann dabei sowohl in die App integriert oder separat verfügbar sein. Zu finden ist eine solche Dokumentation in der Regel in den Einstellungen, auf Hilfeseiten bzw. in Support-Bereichen, in Wikis oder in der Erklärung zur Barrierefreiheit. Zu relevanten Funktionen und Einstellungsmöglichkeiten gehören etwa:
+Wenn es für die Barrierefreiheit relevante Funktionen oder Einstellungsmöglichkeiten gibt, sollen diese in der Dokumentation aufgelistet und erklärt werden. Die Dokumentation kann dabei sowohl in die App integriert oder separat verfügbar sein. Zu finden ist eine solche Dokumentation in der Regel in den Einstellungen, auf Hilfeseiten bzw. in Support-Bereichen, in Wikis oder in der Erklärung zur Barrierefreiheit. Die Dokumentation muss dabei z. B. folgende Informationen enthalten, sofern relevant::
 
-* Barrierefreiheitserklärung nach EU-Richtlinie 2016/2102
+* Barrierefreiheitserklärung nach EU-Richtlinie 2016/2102 (ggf. verlinkt)
 * Einzelheiten zu angebotenen Barrierefreiheits-Einstellungen, sofern diese in der App selbst integriert sind, zum Beispiel:
 ** Vorlesefunktion
 ** Einstellungsmögliochkeiten für individueller Farbschemata 

--- a/Prüfschritte/de/12.1.1 Dokumentation von Kompatibilität und Barrierefreiheit.adoc
+++ b/Prüfschritte/de/12.1.1 Dokumentation von Kompatibilität und Barrierefreiheit.adoc
@@ -33,12 +33,8 @@ Wenn es für die Barrierefreiheit relevante Funktionen oder Einstellungsmöglich
 ** Hinweise auf unterstützte Umgebungen, falls es Einschränkungen bei der Nutzbarkeit mit assistiven Technologien gibt
 ** Deaktivierung von Bewegungen oder automatischem Abspielen von Video- oder Audio-Inhalten
 
-
-
 Für die Prüfpraxis sind weitere Hinweise notwendig, auf GitHub können Sie
 https://github.com/BIK-BITV/BIK-App-Test/issues[dazu ein Issue eröffnen].
-
-
 
 
 == Quellen

--- a/Prüfschritte/de/12.1.1 Dokumentation von Kompatibilität und Barrierefreiheit.adoc
+++ b/Prüfschritte/de/12.1.1 Dokumentation von Kompatibilität und Barrierefreiheit.adoc
@@ -30,9 +30,9 @@ Wenn es für die Barrierefreiheit relevante Funktionen oder Einstellungsmöglich
 
 === 3. Hinweise
 
-. Das Fehlen von zusätzlichen Barrierefreiheits-Funktionen wird nicht negativ bewertet. Wenn sie eingesetzt werden, müssen sie aber dokumentiert sein.
+* Das Fehlen von zusätzlichen Barrierefreiheits-Funktionen wird nicht negativ bewertet. Wenn sie eingesetzt werden, müssen sie aber dokumentiert sein.
 
-. Es wird nur die Dokumentation von Barrierefreiheits-Funktionen verlangt, die von der App selbst implementiert werden. Dazu gehören auch Features wie Vorlesefunktionen, die von Drittanbietern definiert und im Angebot eingebunden werden. Barrierefreiheits-Funktionen des jeweiligen Betriebssystems müssen dagegen nicht dokumentiert werden.
+* Es wird nur die Dokumentation von Barrierefreiheits-Funktionen verlangt, die von der App selbst implementiert werden. Dazu gehören auch Features wie Vorlesefunktionen, die von Drittanbietern definiert und im Angebot eingebunden werden. Barrierefreiheits-Funktionen des jeweiligen Betriebssystems müssen dagegen nicht dokumentiert werden.
 
 Für die Prüfpraxis sind weitere Hinweise notwendig, auf GitHub können Sie
 https://github.com/BIK-BITV/BIK-App-Test/issues[dazu ein Issue eröffnen].

--- a/Prüfschritte/de/12.1.1 Dokumentation von Kompatibilität und Barrierefreiheit.adoc
+++ b/Prüfschritte/de/12.1.1 Dokumentation von Kompatibilität und Barrierefreiheit.adoc
@@ -23,7 +23,7 @@ Dieser Prüfschritt ist anwendbar, wenn es Dokumentation zur Barrierefreiheit un
 
 === 2. Prüfung
 
-Wenn es für die Barrierefreiheit relevante Funktionen oder Einstellungsmöglichkeiten gibt, sollen diese in der Dokumentation aufgelistet und erklärt werden. Die Dokumentation kann dabei sowohl in die App integriert oder separat verfügbar sein. Zu finden ist solche Dokumentation in der Regel ubnter Einstellungen, auf Hilfeseiten bzw. in Support-Bereichen, Wikis oder in der Erklärung zur Barrierefreiheit. Dazu gehört etwa:
+Wenn es für die Barrierefreiheit relevante Funktionen oder Einstellungsmöglichkeiten gibt, sollen diese in der Dokumentation aufgelistet und erklärt werden. Die Dokumentation kann dabei sowohl in die App integriert oder separat verfügbar sein. Zu finden ist solche Dokumentation in der Regel in den Einstellungen, auf Hilfeseiten bzw. in Support-Bereichen, in Wikis oder in der Erklärung zur Barrierefreiheit. Zu relevanten Funktionen und Einstellungsmöglichkeiten gehören etwa:
 
 * Barrierefreiheitserklärung nach EU-Richtlinie 2016/2102
 * Einzelheiten zu angebotenen Barrierefreiheits-Einstellungen, sofern diese in der App selbst integriert sind, zum Beispiel:


### PR DESCRIPTION
Unklar ist hier, wann eine Erklärung zur Barrierefreiheit für Apps verlangt wird und wann ihr Fehlen hier negativ zu Buche schlägt. Wahrscheinlich nur bei solchen Apps, die der Webrichtlinie unterliegen?

- Wenn ansonsten keine besonderen Funktionen angeboten werden (wie in den meisten Apps) und das Angebot nicht der Richtlinie unterliegt, wäre der PS wohl erfüllt? 
- Und wenn er der Richtlinie unterliegt, wäre er erfüllt, sobald eine Erklärung zur Barrierefreiheit vorhanden ist (in der App oder im Appstore). 
- Wäre im letzteren Fall inhaltlich zu prüfen, ob diese ausreichend Mängel auflistet? Denn das ließe sich erst nach Abschluss der Prüfung feststellen und eröffnet eine Grauzone, da unklar ist, ob eine summarische Nennung von Mängeln aus Sicht der Nutzer nicht ausreichend ist bzw. wieviel Detaillierung eigentlich verlangt würde. Sicher nicht Details auf der Ebene jeder einzelnen Anforderung, denke ich.