### PR TITLE
11.5.2.13/11.5.2.14 Ergänzung Bedienhinweise iOS/VoiceOver zu Fokusposition und Textauswahl

### DIFF
--- a/Prüfschritte/de/11.5.2.13 Fokusverfolgung Texteinfügemarke und Textauswahl.adoc
+++ b/Prüfschritte/de/11.5.2.13 Fokusverfolgung Texteinfügemarke und Textauswahl.adoc
@@ -27,6 +27,13 @@ Die Textauswahl kann je nach Screenreader und Betriebssystem unterschiedlich sei
 * Die Fokusposition wird in der Regel mit den Lautstärketasten des Geräts versetzt.
 * Über das lokale Kontextmenü (Wischen nach oben und dann nach rechts) können Optionen zum Textauswahl-Modus, zum Kopieren usw. aufgerufen werden
 
+=== iOS / VoiceOver
+
+* Durch Doppeltippen wird die Einfügemarke bei wiederholter Anwendung zwischen Anfang und Ende des Texts hin und her verschoben.
+* Im Rotor eine der Optionen Zeichen/Wörter einstellen. Anschließend durch Streichen mit einem Finger von oben nach unten bzw. unten nach oben die Fokusposition versetzen.
+* Text-Auswahl: Zoom-Geste (Pinch bzw. Finger auseinander ziehen / zusammen ziehen) anwenden, entsprechend werden Zeichen/Worte markiert.
+* Kopieren/Einfügen (u. ä.): Im Rotor die Option Bearbeiten wählen. Anschließend durch Streichen mit einem Finger von oben nach unten die zugehörige Option auswählen und doppeltippen.
+
 == Quellen
 * https://support.google.com/accessibility/android/answer/6151827?hl=en#zippy=%2Cversion-up%2Cversion-lower[Google-Hilfe zu TalkBack-Gesten]
 * https://bbc.github.io/accessibility-news-and-you/accessibility-and-testing-with-talkback.html[BBC Accessibility and Testing with TalkBack]

--- a/Prüfschritte/de/11.5.2.14 Programmatisch steuerbare Texteinfügemarke und Selektion.adoc
+++ b/Prüfschritte/de/11.5.2.14 Programmatisch steuerbare Texteinfügemarke und Selektion.adoc
@@ -39,6 +39,13 @@ Die Textauswahl kann je nach Screenreader und Betriebssystem unterschiedlich sei
 * Die Fokusposition wird in der Regel mit den Lautstärketasten des Geräts versetzt.
 * Über das lokale Kontextmenü (Wischen nach oben und dann nach rechts) können Optionen zum Textauswahl-Modus, zum Kopieren usw. aufgerufen werden
 
+=== iOS / VoiceOver
+
+* Durch Doppeltippen wird die Einfügemarke bei wiederholter Anwendung zwischen Anfang und Ende des Texts hin und her verschoben.
+* Im Rotor eine der Optionen Zeichen/Wörter einstellen. Anschließend durch Streichen mit einem Finger von oben nach unten bzw. unten nach oben die Fokusposition versetzen.
+* Text-Auswahl: Zoom-Geste (Pinch bzw. Finger auseinander ziehen / zusammen ziehen) anwenden, entsprechend werden Zeichen/Worte markiert.
+* Kopieren/Einfügen (u. ä.): Im Rotor die Option Bearbeiten wählen. Anschließend durch Streichen mit einem Finger von oben nach unten die zugehörige Option auswählen und doppeltippen.
+
 === 4. Bewertung
 
 ==== Erfüllt:


### PR DESCRIPTION
Detlev, du hattest in #41 bereits eine Quelle zur Bedienung der Verschiebung Fokusposition und Textauswahl in Eingabefeldern unter iOS bereitgestellt. Ich habe die Bedienweise jetzt auf iOS 14 ausprobiert. Es funktioniert genau wie in dem Beitrag angegeben. Entsprechend habe ich in den beiden Prüfschritten 11.5.2.13 und 11.5.2.14 analog zu Android/TalkBack eine kurze Anleitung für VoiceOver im Hinweisbereich ergänzt.