### PR TITLE
Update 11.1.3.1e Beschriftung von Formularelementen programmatisch er…

### DIFF
--- a/Prüfschritte/de/11.1.3.1e Beschriftung von Formularelementen programmatisch ermittelbar.adoc
+++ b/Prüfschritte/de/11.1.3.1e Beschriftung von Formularelementen programmatisch ermittelbar.adoc
@@ -4,102 +4,59 @@ include::include/attributes.adoc[]
 
 == Was wird geprüft?
 
-Beschriftungen sollen über die entsprechende Auszeichnung im Programm-Code
-mit den Eingabefeldern verknüpft sein, zu denen sie gehören.
+Beschriftungen sollen über die entsprechende Auszeichnung im Programm-Code mit den Eingabefeldern verknüpft sein, zu denen sie gehören.
 
-Visuell voneinander abgesetzte oder logisch miteinander verbundene Gruppen von
-Formularelementen sind z. B. mithilfe von Überschriften sinnvoll strukturiert.
+Visuell voneinander abgesetzte oder logisch miteinander verbundene Gruppen von Formularelementen sind z. B. mithilfe von Überschriften sinnvoll strukturiert.
 
-Ist bei Gruppen von Formularelementen eine Gruppenbeschriftung für das
-Verständnis der Beschriftung der einzelnen Formularelemente nötig, sollte
-die Verfügbarkeit sichergestellt werden.
+Ist bei Gruppen von Formularelementen eine Gruppenbeschriftung für das Verständnis der Beschriftung der einzelnen Formularelemente nötig, sollte die Verfügbarkeit sichergestellt werden.
 
 == Warum wird das geprüft?
 
-Die Verknüpfung von Beschriftungen mit den zugeordneten Eingabefeldern stellt
-sicher, dass der Aufbau einer Software-Ansicht unabhängig von der
-Präsentation festgelegt und zugänglich ist:
+Die Verknüpfung von Beschriftungen mit den zugeordneten Eingabefeldern stellt sicher, dass der Aufbau einer Software-Ansicht unabhängig von der Präsentation festgelegt und zugänglich ist:
 
-* Der Screenreader liest die Beschriftungen vor, wenn der Benutzer durch die
-  Formularelemente wandert.
-* Das jeweils aktive Label kann deutlich hervorgehoben werden ggf. kann eine
-  Hilfstechnologie beim Antippen / Anklicken des Labels den Fokus auf das
-  zugehörige Formularelement setzen.
+* Der Screenreader liest die Beschriftungen vor, wenn der Benutzer durch die Formularelemente wandert.
+* Das jeweils aktive Label kann deutlich hervorgehoben werden ggf. kann eine Hilfstechnologie beim Antippen / Anklicken des Labels den Fokus auf das zugehörige Formularelement setzen.
 
-Auch wenn die Beschriftungen der Formularelemente korrekt ausgezeichnet sind so
-kann es sein, dass diese nicht ausreichen und z. B. eine gemeinsame
-Überschrift für das Verständnis notwendig ist.
+Auch wenn die Beschriftungen der Formularelemente korrekt ausgezeichnet sind so kann es sein, dass diese nicht ausreichen und z. B. eine gemeinsame Überschrift für das Verständnis notwendig ist.
 
 == Wie wird geprüft?
 
-=== Anwendbarkeit des Prüfschritts
+=== 1. Anwendbarkeit des Prüfschritts
 
-Der Prüfschritt ist anwendbar, wenn die Software-Ansicht Formularelemente
-enthält.
+Der Prüfschritt ist anwendbar, wenn die App-Ansicht Formularelemente enthält.
 
-=== Prüfung
+=== 2. Prüfung
 
-Ob die Semantik im Quelltext der Anwendung korrekt gesetzt ist, kann in der
-Regel nicht ohne weiteres festgestellt werden.
-Hier muss dann ein Blackbox-Test z. B. mittels Screenreader durchgeführt
-werden.
-Zu beachten ist, das hier auch gruppierte Bedienelemente ggf. eine
-Gruppenbeschriftung benötigen und diese muss auch vom Screenreader ausgegeben
-werden können.
+Ob die Semantik im Quelltext der Anwendung korrekt gesetzt ist, kann in der Regel nicht ohne weiteres festgestellt werden. Hierfür muss ein Test mittels Screenreader durchgeführt werden. Zu beachten ist, dass gruppierte Bedienelemente ggf. eine Gruppenbeschriftung benötigen und diese dann auch vom Screenreader ausgegeben werden muss.
 
 . Screenreader starten
 . Zu testende App starten
-. Über Formularelemente navigieren bzw. diese direkt antippen und prüfen, ob
-  dessen Beschriftungen *und* Gruppenbeschriftungen korrekt
-  ausgegeben werden.
+. Zu Formularelementen per Wischgesten navigieren bzw. diese direkt antippen und prüfen, ob dessen Beschriftungen bzw. gegebnenfalls Gruppenbeschriftungen bei gruppierten Elementen korrekt ausgegeben werden.
 
-=== Hinweise
+=== 3. Hinweise
 
-==== Kombinierte Eingabeelemente
+==== 3.1 Kombinierte Eingabeelemente
 
-Bei kombinierten Eingabeelementen hat nicht immer jedes Element eine
-zugeordnete Beschriftung.
-In diesem Fall sollen Elemente mit einer passenden (nicht sichtbaren)
-Bezeichnung für Screenreader versehen werden.
-Beispiel:
-In einem Formular werden für die Eingabe eines Datums drei Auswahllisten
-angeboten (Tag, Monat und Jahr).
-Die drei Auswahllisten haben eine gemeinsame Beschriftung: Datum.
-Die Auswahllisten für Tag, Monat und Jahr sind mit einer erklärenden
-Bezeichnung für Screenreader versehen.
-Diese Bezeichnungen sind dann nur von der Hilfstechnologie auswertbar, die
-entsprechenden Bezeichnungen sind nicht sichtbar.
+Bei kombinierten Eingabeelementen hat nicht immer jedes Element eine zugeordnete Beschriftung. In diesem Fall sollen Elemente mit einer passenden (nicht sichtbaren) Bezeichnung für Screenreader versehen werden.
 
-Wenn ein einfaches Suchformular nur aus einem Eingabefeld und einem Button
-besteht, ist oftmals keine sichtbare Beschriftung notwendig.
-Hier ist es ausreichend, wenn Eingabefeld und Button direkt nebeneinander
-positioniert sind, das Eingabefeld eine sinnvolle Textvorbelegung hat oder die
-Beschriftung des Buttons die Funktion eindeutig kennzeichnet (etwa "Suchen").
-Das unbeschriftete Eingabefeld mit Textvorbelegung muss in solchen Fällen
-eine aussagekräftige (nicht sichtbare) Bezeichnung für den Screenreader
-haben, da für Screenreader-Nutzer der nachfolgende Button nicht
-gleichermaßen als Beschriftung taugt.
+Beispiel: In einem Formular werden für die Eingabe eines Datums drei Auswahllisten angeboten (Tag, Monat und Jahr). Die drei Auswahllisten haben eine gemeinsame Beschriftung: Datum. Die Auswahllisten für Tag, Monat und Jahr sind mit einer erklärenden Bezeichnung für Screenreader versehen. Diese Bezeichnungen sind dann nur von der Hilfstechnologie auswertbar, die entsprechenden Bezeichnungen sind nicht sichtbar.
 
-==== Verhindern des separaten vorlesens von Label und Bedienelement
+Wenn ein einfaches Suchformular nur aus einem Eingabefeld und einem Button besteht, ist oftmals keine sichtbare Beschriftung notwendig. Hier ist es ausreichend, wenn Eingabefeld und Button direkt nebeneinander positioniert sind, das Eingabefeld eine sinnvolle Textvorbelegung hat oder die Beschriftung des Buttons die Funktion eindeutig kennzeichnet (etwa "Suchen"). Das unbeschriftete Eingabefeld mit Textvorbelegung muss in solchen Fällen eine aussagekräftige (nicht sichtbare) Bezeichnung für den Screenreader haben, da für Screenreader-Nutzer der nachfolgende Button nicht gleichermaßen als Beschriftung taugt.
 
-In der Praxis kommt es immer wieder vor, dass Label und dessen Bedienelement
-getrennt voneinander vorgelesen werden.
-Dies ist meist dann der Fall, wenn Bedienelement und Label keine
-programmatische Verbindung haben.
-Um die Verbindung programmatisch herzustellen bieten die Plattformen
-unterschiedliche Mögglichkeiten an.
+==== 3.2 Verhindern des separaten Vorlesens von Label und Bedienelement
+
+In der Praxis kommt es immer wieder vor, dass Label und dessen Bedienelement getrennt voneinander vorgelesen werden. Dies ist meist dann der Fall, wenn Bedienelement und Label keine programmatische Verbindung haben. Um die Verbindung programmatisch herzustellen bieten die Plattformen unterschiedliche Mögglichkeiten an.
 In Apples iOS / iPadOS können diese Elemente
 https://developer.apple.com/documentation/uikit/accessibility/delivering_an_exceptional_accessibility_experience#3542986[
 gruppiert werden], sodass sie für den Screenreader als eine Einheit agieren.
 Für Android gibt es dazu https://developer.android.com/guide/topics/ui/accessibility/principles[
 vergleichbare Ansätze].
 
-=== Bewertung
+=== 3. Bewertung
 
-*Nicht erfüllt:*
+==== Nicht erfüllt:
 
-* Beschriftungen sind nicht korrekt mit den dazugehörigen Eingabefeldern
-  verknüpft.
+* Beschriftungen sind nicht korrekt mit den dazugehörigen Eingabefeldern verknüpft. Es wird bei Fokussierung des Feldes auch kein Name ausgegeben, der das Eingabefeld hinreichend beschreibt.
 
 == Einordnung des Prüfschritts
 

--- a/Prüfschritte/de/11.1.3.1e Beschriftung von Formularelementen programmatisch ermittelbar.adoc
+++ b/Prüfschritte/de/11.1.3.1e Beschriftung von Formularelementen programmatisch ermittelbar.adoc
@@ -4,20 +4,20 @@ include::include/attributes.adoc[]
 
 == Was wird geprüft?
 
-Beschriftungen sollen über die entsprechende Auszeichnung im Programm-Code mit den Eingabefeldern verknüpft sein, zu denen sie gehören.
+Beschriftungen müssen programmatisch mit den entsprechenden Formularelmenten verknüpft werden.
 
 Visuell voneinander abgesetzte oder logisch miteinander verbundene Gruppen von Formularelementen sind z. B. mithilfe von Überschriften sinnvoll strukturiert.
 
-Ist bei Gruppen von Formularelementen eine Gruppenbeschriftung für das Verständnis der Beschriftung der einzelnen Formularelemente nötig, sollte die Verfügbarkeit sichergestellt werden.
+Wenn das Verständnis der Beschriftung einzelner Formularelmente einer Gruppe nicht gegeben ist, so ist eine Gruppenbeschriftung erforderlich.
 
 == Warum wird das geprüft?
 
-Die Verknüpfung von Beschriftungen mit den zugeordneten Eingabefeldern stellt sicher, dass der Aufbau einer Software-Ansicht unabhängig von der Präsentation festgelegt und zugänglich ist:
+Die Verknüpfung von Beschriftungen mit den zugeordneten Eingabefeldern stellt sicher, dass die Struktur unabhängig von der Präsentation wahrnehmbar und zugänglich ist:
 
-* Der Screenreader liest die Beschriftungen vor, wenn der Benutzer durch die Formularelemente wandert.
+* Der Screenreader liest die Beschriftungen vor, wenn der Benutzer durch die Formularelemente navigiert.
 * Das jeweils aktive Label kann deutlich hervorgehoben werden ggf. kann eine Hilfstechnologie beim Antippen / Anklicken des Labels den Fokus auf das zugehörige Formularelement setzen.
 
-Auch wenn die Beschriftungen der Formularelemente korrekt ausgezeichnet sind so kann es sein, dass diese nicht ausreichen und z. B. eine gemeinsame Überschrift für das Verständnis notwendig ist.
+Auch wenn die Beschriftungen der Formularelemente korrekt ausgezeichnet sind, so kann es sein, dass diese nicht ausreichen und z. B. eine gemeinsame Gruppenbeschriftung für das Verständnis notwendig ist.
 
 == Wie wird geprüft?
 
@@ -39,9 +39,9 @@ Ob die Semantik im Quelltext der Anwendung korrekt gesetzt ist, kann in der Rege
 
 Bei kombinierten Eingabeelementen hat nicht immer jedes Element eine zugeordnete Beschriftung. In diesem Fall sollen Elemente mit einer passenden (nicht sichtbaren) Bezeichnung für Screenreader versehen werden.
 
-Beispiel: In einem Formular werden für die Eingabe eines Datums drei Auswahllisten angeboten (Tag, Monat und Jahr). Die drei Auswahllisten haben eine gemeinsame Beschriftung: Datum. Die Auswahllisten für Tag, Monat und Jahr sind mit einer erklärenden Bezeichnung für Screenreader versehen. Diese Bezeichnungen sind dann nur von der Hilfstechnologie auswertbar, die entsprechenden Bezeichnungen sind nicht sichtbar.
+Beispiel: In einem Formular werden für die Eingabe eines Datums drei Auswahllisten angeboten (Tag, Monat und Jahr). Die drei Auswahllisten haben eine gemeinsame Beschriftung: Datum. Die Auswahllisten für Tag, Monat und Jahr sind mit einer erklärenden Bezeichnung für Screenreader versehen. Diese Bezeichnungen sind dann nur von der Hilfstechnologie verfügbar, die entsprechenden Bezeichnungen sind nicht sichtbar.
 
-Wenn ein einfaches Suchformular nur aus einem Eingabefeld und einem Button besteht, ist oftmals keine sichtbare Beschriftung notwendig. Hier ist es ausreichend, wenn Eingabefeld und Button direkt nebeneinander positioniert sind, das Eingabefeld eine sinnvolle Textvorbelegung hat oder die Beschriftung des Buttons die Funktion eindeutig kennzeichnet (etwa "Suchen"). Das unbeschriftete Eingabefeld mit Textvorbelegung muss in solchen Fällen eine aussagekräftige (nicht sichtbare) Bezeichnung für den Screenreader haben, da für Screenreader-Nutzer der nachfolgende Button nicht gleichermaßen als Beschriftung taugt.
+Wenn ein einfaches Suchformular nur aus einem Eingabefeld und einem Button besteht, ist oftmals keine sichtbare Beschriftung notwendig. Hier ist es ausreichend, wenn Eingabefeld und Button direkt nebeneinander positioniert sind, das Eingabefeld eine sinnvolle Textvorbelegung hat oder die Beschriftung des Buttons die Funktion eindeutig kennzeichnet (etwa "Suchen"). Das unbeschriftete Eingabefeld mit Textvorbelegung muss in solchen Fällen eine aussagekräftige (nicht sichtbare) Bezeichnung für den Screenreader haben, da für Screenreader-Nutzende der nachfolgende Button nicht gleichermaßen als Beschriftung taugt.
 
 ==== 3.2 Verhindern des separaten Vorlesens von Label und Bedienelement
 
@@ -62,8 +62,7 @@ vergleichbare Ansätze].
 
 === Abgrenzung von anderen Prüfkriterien
 
-Ob bei Nutzung von gruppierenden Überschriften der Text zusammen mit
-verknüpften Beschriftungen der Formularfelder (label) Sinn ergibt, wird in
+Ob bei Nutzung von Gruppenbeschriftungen der Text zusammen mit verknüpften Beschriftungen der Formularfelder (label) Sinn ergibt, wird in
 Prüfschritt
 ifdef::env_embedded[11.2.4.6 "Aussagekräftige Überschriften und Beschriftungen"]
 ifndef::env_embedded[]


### PR DESCRIPTION
* Ergänzung bei "Nicht erfüllt", um auch Fälle abzudecken, wo es keine Verküpfung (bzw. Gruppierung von Element u. Beschriftung mit geeignetem AccessibilityLabel) gibt, aber ggf. einen anderweitig hinterlegten Namen - dann wäre ja eine Name unabhängig von der sichtbaren Beschriftung programmatisch ermittelbar.
* Vervollständigung der Nummerierung
* Kleinere Änderungen in der Prüfanleitung

Die Beschreibung unter "3.1 Kombinierte Eingabeelemente" zielt zur Zet auf die Spezialfälle wie Datumsfelder, wenn die aus mehreren Feldern bestehen. Sie sollte aber auch (vielleicht vorrangig) den Fall abdecken, dass verschiedene Elemente (z.B. grafische Eingabe-Elemente wie Custom-Checkboxes und deren Beschriftungen) gruppiert wurden. Wenn ich es richtig verstanden habe, ersetzt die Gruppenbeschriftung des parents ggf. automatisch die Beschriftungen der children, in dem (bei iOS z.B.) der Wert des UIAccessibilityElement-Attributs `isAccessibilityElement` defaultmäßig auf `false` gesetzt wird, sobald der Wert des gruppierenden Parent Elements `true` ist. Das müssen wir möglichst noch genauer recherchieren. Es ist mir auch nicht recht klar, ob im nativen Kontext die Verwendung des Begriffs _Verküpfung_ sinnvoll ist - das wäre ja nur der Fall, wenn es nativ ähnliche Konstrukte wie` label for=[id]` gibt. Ist das der Fall?