### PR TITLE
1.3.1.c redaktionelles update

### DIFF
--- a/Prüfschritte/de/11.1.3.1c Text programmatisch verfügbar.adoc
+++ b/Prüfschritte/de/11.1.3.1c Text programmatisch verfügbar.adoc
@@ -23,6 +23,10 @@ Der Prüfschritt ist anwendbar, wenn in der App Textinhalte vorhanden sind, die 
 . Prüfen, ob der Screenreader alle Textinhalte ausgibt.
 . Wenn es sich um Bedienelemente handelt, kann die Ausgabe mitunter vom sichtbaren Text abweichen (beachte aber Prüfschritt 11.2.5.3 Beschriftung im zugänglichen Namen).
 
+=== 3. Bewertung
+==== Nicht voll erfüllt
+Nicht alle Textinhalte, die Informationen vermitteln, werden vom Screenreader ausgegeben.
+
 == Einordnung des Prüfschritts
 
 === Einordnung des Prüfschritts nach WCAG 2.1

--- a/Prüfschritte/de/11.1.3.1c Text programmatisch verfügbar.adoc
+++ b/Prüfschritte/de/11.1.3.1c Text programmatisch verfügbar.adoc
@@ -21,7 +21,6 @@ Der Prüfschritt ist anwendbar, wenn in der App Textinhalte vorhanden sind, die 
 . App mit zu prüfender Ansicht öffnen.
 . Screenreader starten und mittels Wischgesten durch alle Inhalte navigieren bzw. diese direkt antippen.
 . Prüfen, ob der Screenreader alle Textinhalte ausgibt.
-. Wenn es sich um Bedienelemente handelt, kann die Ausgabe mitunter vom sichtbaren Text abweichen (beachte aber Prüfschritt 11.2.5.3 Beschriftung im zugänglichen Namen).
 
 === 3. Bewertung
 ==== Nicht voll erfüllt

--- a/Prüfschritte/de/11.1.3.1c Text programmatisch verfügbar.adoc
+++ b/Prüfschritte/de/11.1.3.1c Text programmatisch verfügbar.adoc
@@ -13,15 +13,15 @@ Sie dürfen nicht auf eine Weise implementiert werden, dass sie für den Screenr
 
 == Wie wird geprüft?
 
-=== Anwendbarkeit des Prüfschritts
+=== 1. Anwendbarkeit des Prüfschritts
 
 Der Prüfschritt ist anwendbar, wenn in der App Textinhalte vorhanden sind, die Inhalte vermitteln und für die Nutzung relevant sein können.
 
-=== Prüfung
+=== 2. Prüfung
 
-. Screenreader starten (siehe Handreichung)
-. Zu testende App starten
-. Mit dem Screenreader mittels Wischgesten durch alle Inhalte navigieren bzw. diese direkt antippen und prüfen, ob der Screenreader alle Textinhalte ausgibt.
+. App mit zu prüfender Ansicht öffnen.
+. Screenreader starten und mittels Wischgesten durch alle Inhalte navigieren bzw. diese direkt antippen.
+. Prüfen, ob der Screenreader alle Textinhalte ausgibt.
 . Wenn es sich um Bedienelemente handelt, kann die Ausgabe mitunter vom sichtbaren Text abweichen (beachte aber Prüfschritt 11.2.5.3 Beschriftung im zugänglichen Namen).
 
 == Einordnung des Prüfschritts

--- a/Prüfschritte/de/11.1.3.1c Text programmatisch verfügbar.adoc
+++ b/Prüfschritte/de/11.1.3.1c Text programmatisch verfügbar.adoc
@@ -4,12 +4,11 @@ include::include/attributes.adoc[]
 
 == Was wird geprüft?
 
-Wenn in Apps Text zu sehen ist, soll dieser Text auch vom Screenreader ausgegeben werden können.
+Textinhalte, die Informationen vermitteln, sollen vom Screenreader ausgegeben werden können.
 
 == Warum wird das geprüft?
 
-Textinhalte, die nicht einen rein dekorativen Zweck haben, vermitteln Informationen, die auch bei Nutzung assistiver Technologien verfügbar sein sollen.
-Sie dürfen nicht auf eine Weise implementiert werden, dass sie für den Screenreader-Nutzer unzugänglich sind.
+Textinhalte, die Informationen vermitteln, sollen auch bei Nutzung assistiver Technologien verfügbar sein. Sie dürfen nicht auf eine Weise implementiert werden, dass sie für den Screenreader-Nutzer unzugänglich sind.
 
 == Wie wird geprüft?
 


### PR DESCRIPTION
Redaktionelle Überarbeitung. 
Offene Fragen:
- > Wenn es sich um Bedienelemente handelt, kann die Ausgabe mitunter vom sichtbaren Text abweichen (beachte aber Prüfschritt 11.2.5.3 Beschriftung im zugänglichen Namen).

  Bedienelemente werden hier doch nicht geprüft? Würde diesen Punkt löschen?

- Sollte man hier außerdem prüfen, dass Inhalte, die zusammengehören zusammen vorgelesen werden? D.h. diese Inhalte müssen gruppiert werden?