### PR TITLE
11.1.3.5 eingabefelder vermitteln zweck

### DIFF
--- a/Prüfschritte/de/11.1.3.5 Zweck von Eingaben bestimmen.adoc
+++ b/Prüfschritte/de/11.1.3.5 Zweck von Eingaben bestimmen.adoc
@@ -6,8 +6,7 @@ include::include/attributes.adoc[]
 
 Eingabefelder, die sich auf die Nutzenden selbst beziehen, sollten eine semantisch eindeutige, sprachunabhängige Bestimmung ihres Zweckes ermöglichen.
 
-In iOS/iPadOS und Android können Eingabefelder teilweise für einen bestimmten Zweck ausgezeichnet werden. Z. B. für die Eingabe einer
-E-Mail-Adresse, hier kann dann das Betriebssystem u. a. eine optimierte Tastatur einblenden. Ob dies jedoch für die Konformität ausreicht ist derzeit noch unklar.
+In iOS/iPadOS und Android können Eingabefelder teilweise für einen bestimmten Zweck ausgezeichnet werden. Für die Eingabe einer E-Mail-Adresse kann beispielsweise dann das Betriebssystem u. a. eine optimierte Tastatur einblenden. Ob dies jedoch für die Konformität ausreicht, ist derzeit noch unklar.
 
 == Warum wird das geprüft?
 

--- a/Prüfschritte/de/11.1.3.5 Zweck von Eingaben bestimmen.adoc
+++ b/Prüfschritte/de/11.1.3.5 Zweck von Eingaben bestimmen.adoc
@@ -4,87 +4,51 @@ include::include/attributes.adoc[]
 
 == Was wird geprüft?
 
-Eingabefelder, die sich auf den Nutzer selbst beziehen, sollten eine semantisch
-eindeutige, sprachunabhängige Bestimmung ihres Zweckes ermöglichen.
+Eingabefelder, die sich auf die Nutzenden selbst beziehen, sollten eine semantisch eindeutige, sprachunabhängige Bestimmung ihres Zweckes ermöglichen.
 
-In iOS/iPadOS und Android können Eingabefelder teilweise für einen
-bestimmten Zweck ausgezeichnet werden. Z. B. für die Eingabe einer
-E-Mail-Adresse, hier kann dann das Betriebssystem u. a. eine optimierte
-Tastatur einblenden.
-Ob dies jedoch für die Konformität ausreicht ist derzeit noch unklar.
+In iOS/iPadOS und Android können Eingabefelder teilweise für einen bestimmten Zweck ausgezeichnet werden. Z. B. für die Eingabe einer
+E-Mail-Adresse, hier kann dann das Betriebssystem u. a. eine optimierte Tastatur einblenden. Ob dies jedoch für die Konformität ausreicht ist derzeit noch unklar.
+
+== Warum wird das geprüft?
+
+Die Festlegung des Eingabezwecks erlaubt es neuartigen Hilfsmitteln, bei Formularfeldern, welche sich auf Daten der Nutzenden beziehen, zusätzliche Informationen anzuzeigen, und zwar unabhängig vom der jeweils gewählten Beschriftung des Feldes und unabhängig von der natürlichen Sprache des Angebots.
+
+Zusätzliche Informationen können etwa Bilder bzw. Icons sein, die über eine zukünftige assistive Technologie bereitgestellt werden könten und über bzw. vor dem jeweiligen Eingabefeld angezeigt werden, etwa wenn Nutzer eine bestimmte Tastenkombination drücken. Für Menschen, die Schwierigkeiten mit dem Lesen haben oder bevorzugt über Bilder kommunizieren, erleichtert dies eine Identifizierung von nutzerbezogenen Feldern in Formularen.
+
+Darüber hinaus bietet die Auszeichnung des Zwecks Eingabevorschläge für das Feld, welche Nutzende einfach übernehmen können. Das erleichtert die Texteingabe.
+
+== Wie wird geprüft?
+
+=== 1. Anwendbarkeit des Prüfschritts
+
+Der Prüfschritt ist anwendbar, wenn Formular-Eingabefelder vorhanden sind, die sich auf Nutzerdaten beziehen (etwa Login / Anmeldung, Kontaktformulare, oder Ansichten zum Anlegen eines Nutzerprofils).
+Des Weiteren muss das Betriebssystem die Auszeichnung des Eingabezwecks unterstützen. In den Einstellungen zur Barrierefreiheit von Android und iOS müsste eine
+entsprechende Einstellung auftauchen, mit der die Anzeige des Eingabezwecks ein- und ausgeschaltet werden kann. Dies ist zur Zeit (Juni 2020) nicht der Fall.
+
+=== 2. Prüfung
+
+Bei Apps ist die Prüfung eingeschränkt möglich. 
+
+. Über eine Sichtprüfung feststellen, ob z.B. bei Eingabefeldern für E-Mail-Adressen auch die dafür optimierte Tastatur eingeblendet wird.
+. Auf der erscheinenden Tastatur ist dann z. B. gleich das „``@``“-Zeichen und der Punkt verfügbar, ohne erst auf die Symboltastatur wechseln zu müssen.
+Dies ist ein starkes Indiz dafür, dass das Eingabefeld korrekt ausgezeichnet wurde.
+. Da es strittig ist, ob eine solche Auszeichnung ausreicht, muss geprüft werden, ob es möglich ist, in den Android- oder iOS- / iPadOS-Einstellungen die Anzeige des Eingabezwecks systemweit zu aktivieren.
+. Daraufhin prüfen, ob die zu testende App die entsprechende Einstellung auch korrekt umsetzt.
+
+=== 3. Hinweis
+
+Die Anforderung gilt nur für Felder, die sich auf die Nutzenden selbst beziehen. Sie gilt nicht für Seiten bzw. Ansichten, auf denen die Eingabe von
+persönlichen Daten mehrerer Personen möglich ist und die Felder für den Nutzer selbst nicht besonders gekennzeichnet sind. Ein Beispiel dafür sind Ticketbuchungsseiten / -Apps von Fluglinien. Hier sind die Eingabefelder für die Nutzenden nicht von den Feldern für Mitreisende unterscheidbar.
 
 Auf GitHub können Sie zu diesem Prüfschritt ein
 https://github.com/BIK-BITV/BIK-App-Test/issues[Issue eröffnen], falls Sie
 Hinweise zu diesem Prüfschritt haben.
 
-== Warum wird das geprüft?
+=== 4. Bewertung
 
-Die Festlegung des Eingabezwecks erlaubt es neuartigen Hilfsmitteln, bei
-Formularfeldern, welche sich auf Daten des Nutzers beziehen, zusätzliche
-Informationen anzuzeigen, und zwar unabhängig vom der jeweils gewählten
-Beschriftung des Feldes und unabhängig von der natürlichen Sprache des
-Angebots.
+==== Erfüllt
 
-Zusätzliche Informationen können etwa Bilder bzw. Icons sein, die über eine
-zukünftige assistive Technologie bereitgestellt werden köntte und über bzw.
-vor dem jeweiligen Eingabefeld angezeigt werden, etwa wenn Nutzer eine
-bestimmte Tastenkombination drücken.
-Für Menschen, die Schwierigkeiten mit dem Lesen haben oder bevorzugt über
-Bilder kommunizieren, erleichtert dies eine Identifizierung von
-nutzerbezogenen Feldern in Formularen.
-
-Darüber hinaus bietet die Auszeichnung des Zwecks Eingabevorschläge für das
-Feld, welche Nutzer einfach übernehmen können.
-Das erleichtert die Texteingabe.
-
-== Wie wird geprüft?
-
-=== Anwendbarkeit des Prüfschritts
-
-Der Prüfschritt ist anwendbar, wenn Formular-Eingabefelder vorhanden sind,
-die sich auf Nutzerdaten beziehen (etwa Login / Anmeldung, Kontaktformulare,
-oder Ansichten zum Anlegen eines Nutzerprofils).
-Des Weiteren muss das Betriebssystem die Auszeichnung des Eingabezwecks
-unterstützen.
-In den Einstellungen zur Barrierefreiheit von Android und iOS müsste eine
-entsprechende Einstellung auftauchen, mit der die Anzeige des Eingabezwecks
-ein- und ausgeschaltet werden kann.
-Dies ist zur Zeit (Juni 2020) nicht der Fall.
-
-=== Prüfung
-
-Bei Software ist die Prüfung eingeschränkt möglich.
-Hier kann über eine Sichtprüfung z. B. festgestellt werden, ob bei
-Eingabefeldern für E-Mail-Adressen auch die dafür optimierte Tastatur
-eingeblendet wird.
-Auf der dann erscheinenden Tastatur ist dann z. B. gleich das „``@``“-Zeichen
-und der Punkt verfügbar, ohne erst auf die Symboltastatur wechseln zu müssen.
-Dies ist ein starkes Indiz dafür, dass das Eingabefeld in der Software
-korrekt ausgezeichnet wurde.
-Da es strittig ist, ob eine solche Auszeichnung ausreicht, muss geprüft
-werden, ob es in den Android oder iOS / iPadOS Einstellungen eine Möglichkeit
-gibt, die Anzeige des Eingabezwecks systemweit zu aktivieren.
-Daraufhin muss geprüft werden, ob die zu testende Software die entsprechende
-Einstellung auch korrekt umsetzt.
-
-=== Hinweis
-
-Die Anforderung gilt nur für Felder, die sich auf den Nutzer selbst beziehen.
-Sie gilt nicht für Seiten bzw. Ansichten, auf denen die Eingabe von
-persönlichen Daten mehrerer Personen möglich ist und die Felder für den
-Nutzer selbst nicht besonders gekennzeichnet sind.
-Ein Beispiel dafür sind Ticketbuchungsseiten / -Apps von Fluglinien.
-Hier sind die Eingabefelder für den Nutzer nicht von den Feldern für
-Mitreisende unterscheidbar.
-
-=== Bewertung
-
-*Prüfschritt erfüllt:*
-
-* Alle Eingabefelder, die sich klar auf den Nutzer selbst beziehen vermitteln
-  den Zweck des jeweiligen Feldes.
-  Da dies zur Zeit ggf. technisch nicht für alle Felder möglich ist, ist
-  dieser Prüfschritt dann nicht anwendbar.
+* Alle Eingabefelder, die sich klar auf Nutzende selbst beziehen, vermitteln den Zweck des jeweiligen Feldes. Da dies zur Zeit gegebenenfalls technisch nicht für alle Felder möglich ist, ist dieser Prüfschritt dann nicht anwendbar.
 
 == Einordnung des Prüfschritts
 


### PR DESCRIPTION
Redaktionelle Änderungen.

Unklar:
> Da es strittig ist, ob eine solche Auszeichnung ausreicht, muss geprüft werden, ob es möglich ist, in den Android- oder iOS- / iPadOS-Einstellungen die Anzeige des Eingabezwecks systemweit zu aktivieren.

Das ist erläuterungsbedürftig. Was soll man sich darunter vorstellen?
Außerdem: Sollte man das nicht erst dann in den Prüfschritt aufnehmen, wenn es das gibt?