### PR TITLE
11.3.1.1 Verständlichkeit der Prüfung

### DIFF
--- a/Prüfschritte/de/11.3.1.1 Hauptsprache angegeben.adoc
+++ b/Prüfschritte/de/11.3.1.1 Hauptsprache angegeben.adoc
@@ -8,11 +8,9 @@ Die Hauptsprache der App soll angegeben werden.
 
 ==  Warum wird das geprüft?
 
-Screenreader verwenden Wortlisten, in denen die Aussprache der Wörter
-festgelegt ist.
-Sie müssen wissen, in welcher Sprache ein Text verfasst ist, damit sie die
-richtige Wortliste für die Aussprache verwenden und den Text korrekt
-aussprechen können.
+Screenreader verwenden Wortlisten, in denen die Aussprache der Wörter festgelegt ist.
+Sie müssen wissen, in welcher Sprache ein Text verfasst ist, damit sie die richtige Wortliste für die Aussprache verwenden und den Text korrekt aussprechen können.
+Wenn jemand beispielsweise eine deutschsprachige App auf einem englischsprachigen Betriebssystem verwendet, sollen die deutschen Begriffe nicht in englischer Aussprache vorgelesen werden.
 
 == Wie wird geprüft?
 
@@ -22,16 +20,12 @@ Der Prüfschritt ist immer anwendbar.
 
 === Prüfung
 
-Prüfen ob sich die Anwendung an die Systemsprache hält.
-Falls dies nicht der Fall ist, soll die Software ihre verwendete Sprache an
-das System melden.
-Gegebenenfalls ist dies mit einem Screenreader prüfbar, indem man prüft, ob
-der Screenreader eine zur Sprache der Anwendung passende Stimme beim Vorlesen
-der Bedienelemente wählt.
+In den Einstellungen des Betriebssystems wird eine andere Sprache als die der App gewählt. Alternativ kann die Sprache der App auf eine andere Sprache als die des Betriebssystems gesetzt werden. Dazu kann auch in den Betriebssystem-Einstellungen die App aufgerufen werden und dort die Sprache geändert werden (beispielsweise unter iOS möglich).
+
+Prüfen, ob trotz unterschiedlicher System- und App-Sprache die Begriffe in der App vom Screenreader noch in der App-Sprache ausgegeben werden. Oder werden sie fälschlich nach Ausspracheregeln der Systemsprache gesprochen?
 
 Ggf. müssen hier noch bessere Prüfmethoden gefunden werden.
-Die meiste Software richtet sich jedoch nach der Systemsprache und ist somit
-konform.
+Die meiste Software richtet sich jedoch nach der Systemsprache und ist somit konform.
 
 Für Hinweise zur Prüfpraxis erstellen Sie gerne ein https://github.com/BIK-BITV/BIK-App-Test/issues[Issue
 auf GitHub].
@@ -40,15 +34,11 @@ auf GitHub].
 
 *Erfüllt:*
 
-* Die Anwendung hält sich an die Systemsprache oder meldet ihre verwendete
-  Sprache an das System.
+* Die Anwendung hält sich an die Systemsprache oder meldet ihre verwendete Sprache an das System. Der Screenreader spricht die Begriffe immer in der Sprache der App aus.
 
 *Nicht erfüllt:*
 
-* Die Anwendungssoftware hält sich nicht an die Systemsprache und meldet
-  dabei ihre verwendete Hauptsprache nicht an das System, sodass z. B. ein
-  Screenreader eine falsche Sprachausgabe-Engine einsetzt und damit
-  beispielsweise englischer Text mit einer deutschen Stimme vorgelesen wird.
+* Die Anwendungssoftware hält sich nicht an die Systemsprache und meldet dabei ihre verwendete Hauptsprache nicht an das System, sodass z. B. ein Screenreader eine falsche Sprachausgabe-Engine einsetzt und damit beispielsweise englischer Text mit einer deutschen Stimme vorgelesen wird.
 
 ==  Einordnung des Prüfschritts
 

--- a/Prüfschritte/de/11.3.1.1 Hauptsprache angegeben.adoc
+++ b/Prüfschritte/de/11.3.1.1 Hauptsprache angegeben.adoc
@@ -25,8 +25,6 @@ Der Prüfschritt ist immer anwendbar.
 
 . Prüfen, ob trotz unterschiedlicher System- und App-Sprache die Begriffe in der App vom Screenreader noch in der App-Sprache ausgegeben werden. Oder werden sie fälschlich nach Ausspracheregeln der Systemsprache gesprochen?
 
-Die meiste Software richtet sich nach der Systemsprache und ist somit konform.
-
 === 3. Hinweise
 
 Für Hinweise zur Prüfpraxis erstellen Sie gerne ein https://github.com/BIK-BITV/BIK-App-Test/issues[Issue

--- a/Prüfschritte/de/11.3.1.1 Hauptsprache angegeben.adoc
+++ b/Prüfschritte/de/11.3.1.1 Hauptsprache angegeben.adoc
@@ -14,29 +14,31 @@ Wenn jemand beispielsweise eine deutschsprachige App auf einem englischsprachige
 
 == Wie wird geprüft?
 
-=== Anwendbarkeit des Prüfschritts
+=== 1. Anwendbarkeit des Prüfschritts
 
 Der Prüfschritt ist immer anwendbar.
 
-=== Prüfung
+=== 2. Prüfung
 
-In den Einstellungen des Betriebssystems wird eine andere Sprache als die der App gewählt. Alternativ kann die Sprache der App auf eine andere Sprache als die des Betriebssystems gesetzt werden. Dazu kann auch in den Betriebssystem-Einstellungen die App aufgerufen werden und dort die Sprache geändert werden (beispielsweise unter iOS möglich).
+. In den Einstellungen des Betriebssystems eine andere Sprache als die der App wählen. 
+. Alternativ die Sprache der App auf eine andere Sprache als die des Betriebssystems setzen. Dazu in den Betriebssystem-Einstellungen die App aufrufen und dort die Sprache ändern (beispielsweise unter iOS möglich).
 
-Prüfen, ob trotz unterschiedlicher System- und App-Sprache die Begriffe in der App vom Screenreader noch in der App-Sprache ausgegeben werden. Oder werden sie fälschlich nach Ausspracheregeln der Systemsprache gesprochen?
+. Prüfen, ob trotz unterschiedlicher System- und App-Sprache die Begriffe in der App vom Screenreader noch in der App-Sprache ausgegeben werden. Oder werden sie fälschlich nach Ausspracheregeln der Systemsprache gesprochen?
 
-Ggf. müssen hier noch bessere Prüfmethoden gefunden werden.
-Die meiste Software richtet sich jedoch nach der Systemsprache und ist somit konform.
+Ggegebenenfalls müssen hier noch bessere Prüfmethoden gefunden werden. Die meiste Software richtet sich jedoch nach der Systemsprache und ist somit konform.
+
+=== 3. Hinweise
 
 Für Hinweise zur Prüfpraxis erstellen Sie gerne ein https://github.com/BIK-BITV/BIK-App-Test/issues[Issue
 auf GitHub].
 
-=== Bewertung
+=== 3. Bewertung
 
-*Erfüllt:*
+==== Erfüllt:
 
 * Die Anwendung hält sich an die Systemsprache oder meldet ihre verwendete Sprache an das System. Der Screenreader spricht die Begriffe immer in der Sprache der App aus.
 
-*Nicht erfüllt:*
+==== Nicht erfüllt:
 
 * Die Anwendungssoftware hält sich nicht an die Systemsprache und meldet dabei ihre verwendete Hauptsprache nicht an das System, sodass z. B. ein Screenreader eine falsche Sprachausgabe-Engine einsetzt und damit beispielsweise englischer Text mit einer deutschen Stimme vorgelesen wird.
 

--- a/Prüfschritte/de/11.3.1.1 Hauptsprache angegeben.adoc
+++ b/Prüfschritte/de/11.3.1.1 Hauptsprache angegeben.adoc
@@ -32,7 +32,7 @@ Ggegebenenfalls müssen hier noch bessere Prüfmethoden gefunden werden. Die mei
 Für Hinweise zur Prüfpraxis erstellen Sie gerne ein https://github.com/BIK-BITV/BIK-App-Test/issues[Issue
 auf GitHub].
 
-=== 3. Bewertung
+=== 4. Bewertung
 
 ==== Erfüllt:
 
@@ -55,3 +55,12 @@ auf GitHub].
 
 * https://www.w3.org/TR/WCAG21/#language-of-page[3.1.1 Language of Page
   (Level A)]
+
+== Quellen
+
+=== iOS
+* https://www.ralfebert.com/ios-examples/xcode/change-development-language/[Changing the development language of an Xcode project,] (Ralf Ebert, 2019)
+
+=== Android
+* https://www.tutorialspoint.com/how-to-change-the-app-language-programmatically-in-android[How to change the app language programmatically in android?,] (Azhar, 2019)
+* https://www.geeksforgeeks.org/how-to-change-the-whole-app-language-in-android-programmatically/[How to Change the Whole App Language in Android Programmatically?,] (Ankur Pal, 2021)

--- a/Prüfschritte/de/11.3.1.1 Hauptsprache angegeben.adoc
+++ b/Prüfschritte/de/11.3.1.1 Hauptsprache angegeben.adoc
@@ -25,7 +25,7 @@ Der Prüfschritt ist immer anwendbar.
 
 . Prüfen, ob trotz unterschiedlicher System- und App-Sprache die Begriffe in der App vom Screenreader noch in der App-Sprache ausgegeben werden. Oder werden sie fälschlich nach Ausspracheregeln der Systemsprache gesprochen?
 
-Ggegebenenfalls müssen hier noch bessere Prüfmethoden gefunden werden. Die meiste Software richtet sich jedoch nach der Systemsprache und ist somit konform.
+Die meiste Software richtet sich nach der Systemsprache und ist somit konform.
 
 === 3. Hinweise
 


### PR DESCRIPTION
Ich habe die Prüfanleitung zur Prüfung der Sprache aus meiner Sicht etwas verständlicher gestaltet.

Eventuell könnte man auch Quellen angeben, wie Entwickler die Sprache setzen können. Ich hatte mal folgende Seiten gefunden:
iOS: https://www.ralfebert.com/ios-examples/xcode/change-development-language/

Android:
* https://www.tutorialspoint.com/how-to-change-the-app-language-programmatically-in-android
* https://www.geeksforgeeks.org/how-to-change-the-whole-app-language-in-android-programmatically/

Vielleicht kennt auch noch jemand bessere Quellen.