### PR TITLE
Update 6.2.2.2 Programmatische Ermittelbarkeit bei Textnachrichten.adoc

### DIFF
--- a/Prüfschritte/de/6.2.2.2 Programmatische Ermittelbarkeit bei Textnachrichten.adoc
+++ b/Prüfschritte/de/6.2.2.2 Programmatische Ermittelbarkeit bei Textnachrichten.adoc
@@ -1,4 +1,4 @@
-= Prüfschritt 6.2.2.2 Programmatische Ermittelbarkeit bei Textnachrichten
+= Prüfschritt 6.2.2.2 Programmatisch unterscheidbare Anzeige von Echtzeit-Textnachrichten
 include::include/author.adoc[]
 include::include/attributes.adoc[]
 


### PR DESCRIPTION
Prüfschrittname geändert (Jetzt gleichlautend wie entsprechender Web-Prüfschritt).

Spricht etwas dagegen?