### PR TITLE
11.3.3.2 beschriftung von formularelementen vorhanden

### DIFF
--- a/Prüfschritte/de/11.3.3.2 Beschriftungen von Formularelementen vorhanden.adoc
+++ b/Prüfschritte/de/11.3.3.2 Beschriftungen von Formularelementen vorhanden.adoc
@@ -41,6 +41,7 @@ Der Prüfschritt ist anwendbar, wenn die Ansicht der App Formularelemente enthä
 
 === Hinweise
 
+* Eine Textvorbelegung ist keine ausreichende Beschriftung im Sinne dieses Prüfschritts. Es verschwindet bei (auch versehentlichen) Nutzereingaben.
 * Bei kombinierten Eingabeelementen hat nicht immer jedes Element eine zugeordnete Beschriftung. In diesem Fall sollen Elemente mit einem unsichtbaren erklärenden Label versehen werden, welches dann von einem Screenreader ausgegeben werden kann. Beispiel: In einem Formular werden für die Eingabe eines Datums drei Auswahllisten angeboten (Tag, Monat und Jahr). Die drei Auswahllisten haben eine gemeinsame Beschriftung: Datum. Die Auswahllisten für Tag, Monat und Jahr sind jeweils mit einem unsichtbaren erklärenden Label für Hilfstechnologien versehen.
 
 * Wenn ein einfaches Suchformular nur aus einem Eingabefeld und einem Button besteht, ist oftmals keine sichtbare Beschriftung notwendig. Hier ist es ausreichend, wenn Eingabefeld und Button direkt nebeneinander positioniert sind, das Eingabefeld eine sinnvolle Textvorbelegung hat oder die Beschriftung des Buttons die Funktion eindeutig kennzeichnet (etwa "Suchen"). Das unbeschriftete Eingabefeld mit Textvorbelegung muss in solchen Fällen ein aussagekräftiges verstecktes Label haben, da für Screenreader-Nutzer der nachfolgende Button nicht gleichermaßen als Beschriftung taugt.

--- a/Prüfschritte/de/11.3.3.2 Beschriftungen von Formularelementen vorhanden.adoc
+++ b/Prüfschritte/de/11.3.3.2 Beschriftungen von Formularelementen vorhanden.adoc
@@ -4,7 +4,7 @@ include::include/attributes.adoc[]
 
 == Was wird geprüft?
 
-Beschriftungen von Formularelementen sind vorhanden.
+Sichtbare Beschriftungen von Formularelementen sind vorhanden.
 
 Die Beschriftung von Formularelementen soll vor (das heißt links neben oder
 über) dem zugehörigen Eingabefeld angeordnet werden.
@@ -12,11 +12,11 @@ Nur die Beschriftung von Checkboxes und Radiobuttons kann (und sollte
 normalerweise) rechts neben dem zugehörigen Eingabefeld angeordnet werden.
 
 Wenn für die Eingabe ein bestimmtes Format verlangt wird, so sind die
-Anweisungen für alle Benutzer lesbar.
+Anweisungen für alle Nutzenden lesbar.
 
 == Warum wird das geprüft?
 
-Wenn Beschriftungen zur Verfügung gestellt werden, wissen Nutzer, welche
+Wenn Beschriftungen zur Verfügung gestellt werden, wissen Nutzende, welche
 Eingaben erwartet werden und Fehler können vermieden werden.
 
 Die Anordnung von Beschriftungen direkt vor oder über dem Eingabefeld
@@ -28,60 +28,40 @@ schnell klar, welche Beschriftung zu welchem Feld gehört.
 
 === Anwendbarkeit des Prüfschritts
 
-Der Prüfschritt ist anwendbar, wenn die App-Ansicht Formularelemente enthält.
+Der Prüfschritt ist anwendbar, wenn die Ansicht der App Formularelemente enthält.
 
 === Prüfung
 
 . App mit zu prüfender Ansicht öffnen.
-. Sind Beschriftungen vorhanden ?
+. Sind Beschriftungen vorhanden?
 . Sind alle Formularelemente beschriftet?
-. Sind Pflichtfelder in label- oder legend-Elementen klar angezeigt, Wenn zur
-  Anzeige Symbole wie etwa ein Sternchen (*) genutzt werden, muss deren
-  Bedeutung am Beginn des Formulars erklärt sein
-. Wenn Eingabefelder ein bestimmtes Eingabeformat vorgeben, wird dieses vor
-  dem Eingabefeld klar beschrieben? (Beispiele wären "Format der
-  Datumseingabe: TT.MM.JJJJ" oder
-  "Telefonnummer: Nur Zahlen ohne Leerstellen oder Bindestriche eingeben".)
+. Sind Pflichtfelder klar angezeigt, Wenn zur Anzeige Symbole wie etwa ein Sternchen (*) genutzt werden, muss deren Bedeutung am Beginn des Formulars erklärt sein.
+. Wenn Eingabefelder ein bestimmtes Eingabeformat vorgeben, wird dieses vor dem Eingabefeld oder mit Hilfe einer Textvorbelegung klar beschrieben? (Beispiele wären "Format der Datumseingabe: TT.MM.JJJJ" oder "Telefonnummer: Nur Zahlen ohne Leerstellen oder Bindestriche eingeben").
 . Sind Beschriftungen richtig positioniert?
 
 === Hinweise
 
-Bei kombinierten Eingabeelementen hat nicht immer jedes Element eine
-zugeordnete Beschriftung.
-In diesem Fall sollen Elemente mit einem unsichtbaren erklärenden Label
-versehen werden, welches dann von einem Screenreader ausgegeben werden kann.
-Beispiel: In einem Formular werden für die Eingabe eines Datums drei
-Auswahllisten angeboten (Tag, Monat und Jahr).
-Die drei Auswahllisten haben eine gemeinsame Beschriftung:
-Datum.
-Die Auswahllisten für Tag, Monat und Jahr sind jeweils mit einem unsichtbaren
-erklärenden Label für Hilfstechnologien versehen.
+* Bei kombinierten Eingabeelementen hat nicht immer jedes Element eine zugeordnete Beschriftung. In diesem Fall sollen Elemente mit einem unsichtbaren erklärenden Label versehen werden, welches dann von einem Screenreader ausgegeben werden kann. Beispiel: In einem Formular werden für die Eingabe eines Datums drei Auswahllisten angeboten (Tag, Monat und Jahr). Die drei Auswahllisten haben eine gemeinsame Beschriftung: Datum. Die Auswahllisten für Tag, Monat und Jahr sind jeweils mit einem unsichtbaren erklärenden Label für Hilfstechnologien versehen.
 
-Wenn ein einfaches Suchformular nur aus einem Eingabefeld und einem Button
-besteht, ist oftmals keine sichtbare Beschriftung notwendig.
-Hier ist es ausreichend, wenn Eingabefeld und Button direkt nebeneinander
-positioniert sind, das Eingabefeld eine sinnvolle Textvorbelegung hat oder die
-Beschriftung des Buttons die Funktion eindeutig kennzeichnet (etwa "Suchen").
-Das unbeschriftete Eingabefeld mit Textvorbelegung muss in solchen Fällen
-ein aussagekräftiges verstecktes Label haben, da für Screenreader-Nutzer der
-nachfolgende Button nicht gleichermaßen als Beschriftung taugt.
+* Wenn ein einfaches Suchformular nur aus einem Eingabefeld und einem Button besteht, ist oftmals keine sichtbare Beschriftung notwendig. Hier ist es ausreichend, wenn Eingabefeld und Button direkt nebeneinander positioniert sind, das Eingabefeld eine sinnvolle Textvorbelegung hat oder die Beschriftung des Buttons die Funktion eindeutig kennzeichnet (etwa "Suchen"). Das unbeschriftete Eingabefeld mit Textvorbelegung muss in solchen Fällen ein aussagekräftiges verstecktes Label haben, da für Screenreader-Nutzer der nachfolgende Button nicht gleichermaßen als Beschriftung taugt.
 
-Es kann sinnvoll sein, dass bei Formularen Hinweise zum Eingabeformat oder zu
-ausgelösten Aktionen einmal am Beginn des Formulars stehen statt vor jedem
-einzelnen Eingabefeld.
+* Es kann sinnvoll sein, dass bei Formularen Hinweise zum Eingabeformat oder zu ausgelösten Aktionen einmal am Beginn des Formulars stehen statt vor jedem einzelnen Eingabefeld.
 
 === Bewertung
 
-*Nicht erfüllt:*
+==== Nicht erfüllt:
 
-* Wichtige Formularelemente (z.B. die Sucheingabe) sind ohne Beschriftung, auch
-  angrenzende Elemente erklären nicht die Funktion.
+* Wichtige Formularelemente (z.B. die Sucheingabe) sind ohne Beschriftung, auch angrenzende Elemente erklären nicht die Funktion.
 
-*Nicht voll erfüllt:*
+==== Nicht voll erfüllt:
 
-* Beschriftungen werden nur als Formularfeld-Vorbelegung bereitgestellt.
+* Beschriftungen werden nur als Textvorbelegung bereitgestellt.
 
 == Einordnung des Prüfschritts
+
+=== Abgrenzung von anderen Prüfschritten
+
+In diesem Prüfschritt geht es um sichtbare Beschriftungen. Das Vorhandensein programmatisch ermittelbarer Namen von Formularelementen wird dagegen in Prüfschritt 11.1.3.1h "Beschriftung von Formularelementen programmatisch ermittelbar" geprüft.
 
 === Einordnung des Prüfschritts nach WCAG 2.1
 


### PR DESCRIPTION
Kleinere redatkionelle Änderungen.

Noch zu klären (unter Hinweise):

> Bei kombinierten Eingabeelementen hat nicht immer jedes Element eine zugeordnete Beschriftung. In diesem Fall sollen Elemente mit einem unsichtbaren erklärenden Label versehen werden, welches dann von einem Screenreader ausgegeben werden kann. Beispiel: In einem Formular werden für die Eingabe eines Datums drei Auswahllisten angeboten (Tag, Monat und Jahr). Die drei Auswahllisten haben eine gemeinsame Beschriftung: Datum. Die Auswahllisten für Tag, Monat und Jahr sind jeweils mit einem unsichtbaren erklärenden Label für Hilfstechnologien versehen.

Ist das wirklich akzeptabel (der Absatz wurde vermutlich vom Web-Prüfschritt übernommen, hier wird auf das title-Attribut zurückgegriffen)? Da diesess für Apps nicht einsetzbar ist, sollte in so einem Fall für jedes Select ein sichtbares label zur Verfügung gestellt werden. Vorschlag: Hinweis streichen.