### PR TITLE
Update 11.1.4.4 Text auf 200% vergrößerbar.adoc

### DIFF
--- a/Prüfschritte/de/11.1.4.4 Text auf 200% vergrößerbar.adoc
+++ b/Prüfschritte/de/11.1.4.4 Text auf 200% vergrößerbar.adoc
@@ -10,11 +10,11 @@ Text soll um bis zu 200 Prozent geändert werden können, ohne dass dabei Inhalt
 * Mit der Funktion des Betriebssystems kann der Text vergrößert werden.
 * Über ein Bedienelement der App-Ansicht kann die Schriftgröße vergrößert werden.
 
-Da die gängigen mobilen Plattformen wie iOS / iPadOS und Android Bedienungshilfen mit Vergrößerungsfunktionalitäten anbieten, ist dieser Prüfschritt erfüllt, wenn die Software ordungsgemäß mit diesen Systemfunktionen nutzbar ist.
+Da die gängigen mobilen Plattformen wie iOS / iPadOS und Android Bedienungshilfen mit Vergrößerungsfunktionalitäten anbieten, ist dieser Prüfschritt erfüllt, wenn Textinhalte der App mit einer der verfügbaren systemseitigen Bedienungshilfen oder über ein App-interne Funktion auf 200% vergrößerbar sind.
 
 == Warum wird das geprüft?
 
-Nutzende sollen die Schriftgröße nach ihren Bedürfnissen einstellen können. Die gängigen Betriebssysteme bieten zwei verschiedene Vergrößerungsmöglichkeiten: die Zoom-Vergrößerung des gesamten Bildschirminhalts und "größerer dynamischer Text".
+Nutzende sollen die Schriftgröße nach ihren Bedürfnissen einstellen können.
 
 == Wie wird geprüft?
 
@@ -26,16 +26,14 @@ Der Prüfschritt ist anwendbar, wenn die App-Ansicht Text enthält.
 
 ==== 2.1 Prüfung der Schriftvergrößerung mit Hilfe der Betriebssystem-Einstellungen
 
-. Zoom-Funktionalität in den Bedienungshilfen von iOS / iPadOS bzw. Android aktivieren
-. App mit zu prüfender Ansicht öffnen
-. Ansicht mittels der Zoomfunktion des Betriebssystems um 200% vergrößern und dabei prüfen, ob dies Probleme bei der zu prüfenden Ansicht hervorruft.
+. Zoom-Funktionalität in den Bedienungshilfen von iOS / iPadOS bzw. Android aktivieren.
+. App mit zu prüfender Ansicht öffnen.
+. Ansicht mittels der Zoomfunktion des Betriebssystems um 200% vergrößern und dabei prüfen, ob die Vergrößerung möglich ist.
+. Schriftvergrößerung aktivieren: bei iOS "Größerer Text" aktivieren, bei Android "Schriftgröße" mit dem Schieberegler auf die größte Stufe stellen. Änderungen wirken sich nur auf Inhalte aus, die als dynamischer Text angelegt wurden.
 
 ==== 2.2 Prüfung der Schriftvergrößerung durch Bedienelemente in der App
 
 Wenn die Software eigene Bedienelemente bereithält, um die Schriftgröße zu vergrößern:
-
-Muss nur geprüft werden, wenn die Systemfunktion zum vergrößern nicht vorhanden ist oder diese mit der App zu Problemen führt.
-
 . Prüfen, ob die Bedienelemente für Schriftvergrößerung deutlich sichtbar im oberen Bereich der Ansicht angeboten werden.
 . Prüfen, ob die Schrift mit Hilfe der auf der Ansicht angebotenen Bedienelemente schrittweise vergrößert werden kann (wie stark die Vergrößerung ist spielt dabei keine  Rolle).
 . Prüfen, ob sich über die angebotenen Bedienelemente die Ausgangsschriftgröße wiederherstellen lässt.


### PR DESCRIPTION
* Anpassungen bei "wie wird geprüft". 
* Unklar ist, wann eine Zoomvergrößerung in nativen Apps überhaupt "Probleme hervorruft" - diese Formulierung war schwammig, ich habe sie deshalb erstmal rausgenommen. Früher konnte Zoomvergrößerung bei Web-Inhalten in mobilen UA unter bestimmten Umständen unterbunden werden. Ob das Unterbinden auch bei nativen Apps überhaupt möglich wäre, weiß ich nicht.  
* Denkbar ist es, Beispiele zu nennen, in denen Inhalte bei Zoomvergrößerung nicht mehr nutzbar wären, weil der Überblick fehlt oder das Bewegen des Ausschnitts Funktionen invalidiert (z.B. ein Popup-Menü öffnet sich, die Menüinhalte sind ausserhalb des sichtbaren Bereichs, ein Verschieben des Ausschnitts schließt das Menü, bevor die gewünschte Option erreicht wird). Eher unwahrscheinlich, aber vielleicht theoretisch denkbar (z.B: wenn sich ein Menü nach einem kurzen Time-out schließen würde). Auch Drag-n-Drop Funktionen sind evtl. bei Zoom nicht mehr (gut) nutzbar. Hier müssen wir evt. gezielt negativ-Beispiele sammeln.
* Durchsehen könnte man zum Abgleich noch mal die lange Diskussion bei den WCAG Issue  https://github.com/w3c/wcag2ict/issues/4