### PR TITLE
Update and rename 11.1.1.1d Alternativen für CAPTCHAs.adoc to 11.1.1.…

### DIFF
--- a/Prüfschritte/de/11.1.1.1c Alternativen für CAPTCHAs.adoc
+++ b/Prüfschritte/de/11.1.1.1c Alternativen für CAPTCHAs.adoc
@@ -1,4 +1,4 @@
-= 11.1.1.1d Alternativen für CAPTCHAs
+= 11.1.1.1c Alternativen für CAPTCHAs
 include::include/author.adoc[]
 include::include/attributes.adoc[]
 


### PR DESCRIPTION
…1c Alternativen für CAPTCHAs.adoc

Änderung der Nummerierung sinnvoll? Sollten wir auch im webtest 9.1.1.1c entfernen?