### PR TITLE
Update 11.1.4.10 Inhalte brechen um.adoc

### DIFF
--- a/Prüfschritte/de/11.1.4.10 Inhalte brechen um.adoc
+++ b/Prüfschritte/de/11.1.4.10 Inhalte brechen um.adoc
@@ -28,24 +28,28 @@ Bei mobilen Apps wird mit Bedienungshilfen des Betriebssystems der Bildschirmaus
 
 == Wie wird geprüft?
 
-=== Anwendbarkeit des Prüfschritts
+=== 1. Anwendbarkeit des Prüfschritts
 
-Laut EN 301 549 Version 3.1.1 ist dieser Prüfschritt auf Software anwendbar. Wwas her genau geprüft werden kann, ist zur Zeit noch unklar. In der Regel sind App-Inhlate an schmae Viewports angepasst und erfüllen damit diesen Prüfschritt.
+Laut EN 301 549 ist dieser Prüfschritt auf Software anwendbar. Was her genau geprüft werden kann, ist zur Zeit noch unklar. In der Regel sind App-Inhalte an schmale Viewports angepasst und erfüllen damit diesen Prüfschritt.
 
-=== Prüfung
+=== 2. Prüfung
 
 In der Regel ist diese Prüfschritt bei nativen Apps erfüllt, da nicht wie bei Websites ein eigentlicher Umbruch stattfindet. Manche Apps brechen Inhalte bei Ansicht im Querformat anders um. Eine angepasste Darstellung fürs Querformat ist sinnvoll, aber deren Fehlen kein Fehler im Sinne dieses Prüfschritts. 
 
-Für Hinweise zur Prüfpraxis können Sie auf GitHub https://github.com/BIK-BITV/BIK-App-Test/issues[ein Issue] zur diesem Prüfschritt erstellen.
+=== 3. Hinweise
 
-=== Hinweise
-
-Ausnahmen für die Anforderung, dass horizontales Scrollen nicht erforderlich
-ist, sind Inhalte, deren Nutzung ein zweidimensionales Layout voraussetzen,
-etwa Datentabellen, Bilder, Diagramme, Videos, Spiele oder
-Benutzerschnittstellen mit Werkzeugleisten.
+Von der Anforderung, dass alle Informationen und Funktionen verfügbar sind, ohne dass horizontales Scrollen notwendig ist, sind Inhalte ausgenommen, deren Nutzung ein zweidimensionales Layout voraussetzen (etwa Datentabellen, Bilder, Diagramme, Videos, Spiele oder Benutzerschnittstellen mit Werkzeugleisten).
 
 Unklar ist noch, inwieweit in diesem Prüfschritt einstellbare Textvergrößerungen berücksichtigt werden sollten. Sind in der App Einstellungen zur Schriftvergrößerung vorhanden, sollte der Text im sichtbaren Bereich umbrechen. Das gilt bei Einstellungen von großem Text in den Bedienungshilfen auch für Texte, die dnamische Fonts unterstützen. Ggf. kommt es hierbei zu Umbrüchen innerhakb längerer Worte. Dies ist nicht als Fehler zu betrachten.
+
+
+Für Hinweise zur Prüfpraxis können Sie auf GitHub https://github.com/BIK-BITV/BIK-App-Test/issues[ein Issue] zur diesem Prüfschritt erstellen.
+
+// === 4. Bewertung
+
+== Einordnung des Prüfschritts
+
+=== Abgrenzung zu anderen Prüfkriterien
 
 Im Prüfschritt wird nicht geprüft, ob die Zoomvergrößerung auf 400%
 Textinhalte tatsächlich auf 400% oder einen geringeren Wert vergrößert.
@@ -58,9 +62,7 @@ ifndef::env_embedded[]
 vergrößerbar>>.
 endif::env_embedded[]
 
-// === Bewertung
-
 == Quellen
 
-https://www.w3.org/WAI/WCAG21/Understanding/reflow.html[Understanding Reflow]
+https://www.w3.org/WAI/WCAG21/Understanding/reflow.html[Understanding 1.4.11 Reflow]
 (zur Zeit nur auf Englisch verfügbar)

--- a/Prüfschritte/de/11.1.4.10 Inhalte brechen um.adoc
+++ b/Prüfschritte/de/11.1.4.10 Inhalte brechen um.adoc
@@ -4,20 +4,9 @@ include::include/attributes.adoc[]
 
 == Was wird geprüft?
 
-Inhalte sollen bei einer Viewport-Breite von 1280 Pixeln und 400%
-Zoomvergrößerung so umbrechen, dass alle Informationen und Funktionen
-verfügbar sind, ohne dass Nutzer horizontal scrollen müssen.
+Inhalte sollen laut Anforderung bei einer Viewport-Breite von 320 CSS Pixeln so umbrechen, dass alle Informationen und Funktionen verfügbar sind, ohne dass Nutzer horizontal scrollen müssen. Mobile Apps sind in der Regel für die Ausgabe der Inhalte auf den üblichen Viewport-Breiten der Smartphones von heute meist minimal 360 CSS Pixeln optimiert. 
 
-Es wird dabei nicht verlangt, dass alle Inhalte in gleicher Weise in der
-responsiven Ansicht verfügbar sind.
-So sind die sichtbaren Navigationsmenüs einer Standard-Ansicht auf dem
-Desktop häufig nach dem Hereinzoomen (oder bei Nutzung des Angebots auf einem
-Smartphone-Display) nur über eine Ausklappnavigation zugänglich.
-Inhalte können auch in Ausklappbereichen oder über Links auf andere Seiten
-oder Ansichten verfügbar sein.
-
-Ausnahmen gelten für Inhalte, für deren Nutzung ein zweidimensionales Layout
-erforderlich ist, z.B.:
+Ausnahmen für den Umbruch auf die Breite von 320 CSS Pixeln gelten für Inhalte, für deren Nutzung ein zweidimensionales Layout erforderlich ist, z.B.:
 
 * Bilder
 * Landkarten
@@ -26,67 +15,37 @@ erforderlich ist, z.B.:
 * Spiele
 * Präsentationen
 * Datentabellen 
-* Anwendungs-Schnittstellen
-+
-In denen die Bearbeitung von Inhalten die permanente Verfügbarkeit von
-Werkzeugleisten erfordert.
+* Anwendungs-Schnittstellen, in denen die Bearbeitung von Inhalten die permanente Verfügbarkeit von Werkzeugleisten erfordert.
 
-*Hinweis:*
-Dieser Prüfschritt beschränkt sich auf Inhalte, deren primäre
-Schreibrichtung waagerecht ist, wie bei der für die meisten westlichen
-Sprachen benutzten lateinischen Schrift.
-Die zugrunde liegende WCAG-Anforderung gilt in ähnlicher Weise für Inhalte
-mit vertikaler Schreibrichtung.
+=== Hinweis:
+Dieser Prüfschritt beschränkt sich auf Inhalte, deren primäre Schreibrichtung waagerecht ist, wie bei der für die meisten westlichen Sprachen benutzten lateinischen Schrift. Die zugrunde liegende WCAG-Anforderung gilt in ähnlicher Weise für Inhalte mit vertikaler Schreibrichtung.
 
-Bei Software, die für einen horizontalen Bildlauf (z. B. mit vertikalem Text)
-ausgelegt ist, entspricht die Höhe des starting Viewports von 1024 px bei
-400% Zoom.
+Bei mobilen Apps, die für einen horizontalen Bildlauf (z. B. mit vertikalem Text) ausgelegt ist, entspricht die Höhe des starting Viewports von 1024 px bei 400% Zoom.
 
 == Warum wird das geprüft?
 
-Bei mobilen Apps wird mit Systemfunktionen der Bildschirmausschnitt
-vergrößert, hierbei wird jedoch Text nicht umgebrochen und der Prüfschritt
-ist so nicht anwendbar.
-Falls das System eine Nur-Text-Vergrößerung anbietet, sollte der Text in der
-Anwendung korrekt umbrechen.
+Bei mobilen Apps wird mit Bedienungshilfen des Betriebssystems der Bildschirmausschnitt vergrößert, hierbei wird jedoch Text nicht umgebrochen. Der Prüfschritt ist deshalb nicht in der gleichen Weise wie bei Websites anwendbar. Falls die App eine Nur-Text-Vergrößerung anbietet, sollte der Text jedoch korrekt umbrechen.
 
 == Wie wird geprüft?
 
 === Anwendbarkeit des Prüfschritts
 
-Laut EN 301 549 Version 3.1.1 ist dieser Prüfschritt auf Software anwendbar.
-Wie dies jedoch umgesetzt werden soll, ist unklar.
-Ggf. gibt es in zukünftigen Versionen der mobilen Betriebssysteme eine
-entsprechende Bedienungshilfe zum umbrechen von Text, die ein- und
-ausgeschaltet werden kann.
-Dann müssen Apps diese Systemschnittstelle unterstützen.
+Laut EN 301 549 Version 3.1.1 ist dieser Prüfschritt auf Software anwendbar. Wwas her genau geprüft werden kann, ist zur Zeit noch unklar. In der Regel sind App-Inhlate an schmae Viewports angepasst und erfüllen damit diesen Prüfschritt.
 
 === Prüfung
 
-Wie dieser Prüfschritt bei nativer Software geprüft werden kann muss noch
-geklärt werden.
-Wenn vom Betriebssystem eine Bedienungshilfe zum umbrechen von Text
-zur Verfügung gestellt wird, sollten Apps mit der entsprechenden Funktion
-umgehen bzw. zugehörige Methoden implementieren, um diese
-systemseitige Funktion zu unterstützen.
+In der Regel ist diese Prüfschritt bei nativen Apps erfüllt, da nicht wie bei Websites ein eigentlicher Umbruch stattfindet. Manche Apps brechen Inhalte bei Ansicht im Querformat anders um. Eine angepasste Darstellung fürs Querformat ist sinnvoll, aber deren Fehlen kein Fehler im Sinne dieses Prüfschritts. 
 
-Für Hinweise zur Prüfpraxis können Sie auf GitHub
-https://github.com/BIK-BITV/BIK-App-Test/issues[ein Issue] zur diesem
-Prüfschritt erstellen.
+Für Hinweise zur Prüfpraxis können Sie auf GitHub https://github.com/BIK-BITV/BIK-App-Test/issues[ein Issue] zur diesem Prüfschritt erstellen.
 
 === Hinweise
-
-Bei der alternativen Prüfung mit 1280px Viewport-Breite und 400% Zoom soll
-nicht negativ bewertet werden, wenn fest positionierte Inhalte (etwa
-Ausklappmenüs) aufgrund der sehr geringen verfügbaren Höhe des Viewports
-nicht voll erreichbar sind.
-Geprüft wird allein, ob Inhalte erfolgreich in eine Ansicht umbrechen, die
-nicht horizontal gescrollt werden braucht.
 
 Ausnahmen für die Anforderung, dass horizontales Scrollen nicht erforderlich
 ist, sind Inhalte, deren Nutzung ein zweidimensionales Layout voraussetzen,
 etwa Datentabellen, Bilder, Diagramme, Videos, Spiele oder
 Benutzerschnittstellen mit Werkzeugleisten.
+
+Unklar ist noch, inwieweit in diesem Prüfschritt einstellbare Textvergrößerungen berücksichtigt werden sollten. Sind in der App Einstellungen zur Schriftvergrößerung vorhanden, sollte der Text im sichtbaren Bereich umbrechen. Das gilt bei Einstellungen von großem Text in den Bedienungshilfen auch für Texte, die dnamische Fonts unterstützen. Ggf. kommt es hierbei zu Umbrüchen innerhakb längerer Worte. Dies ist nicht als Fehler zu betrachten.
 
 Im Prüfschritt wird nicht geprüft, ob die Zoomvergrößerung auf 400%
 Textinhalte tatsächlich auf 400% oder einen geringeren Wert vergrößert.


### PR DESCRIPTION
Umarbeitung, meist automatisch erfüllt - Hinzufügung der Fragestellung, inwieweit Umbruch systemseitig oder app-seitig vergrößerten Textes geprüft werden sollte.
Ich habe den Hinweis auf Einstellungen für Umbruch in den Bedienungshilfen jetzt mal rausgenommen - ist mir unklar, wie so eine Funktion aussähe, kommt mir sehr theoretisch vor.