### PR TITLE
11.5.2.15 Programmatisch ermittelbare Änderungsmitteilung (Entwurf)

### DIFF
--- a/Prüfschritte/de/11.5.2.15 Programmatisch ermittelbare Änderungsmitteilung.adoc
+++ b/Prüfschritte/de/11.5.2.15 Programmatisch ermittelbare Änderungsmitteilung.adoc
@@ -17,7 +17,7 @@ Zustandsänderungen, die für Nutzende visuell verfügbar sind, sollen auch für
 == Wie wird das geprüft?
 
 === 1. Anwendbarkeit des Prüfschritts
-Der Prüfschritt ist anwendbar, wenn die Ansicht interaktive Bedienelemente hat, die durch Eingaben von Nutzenden ihren Wert ändern können oder den Wert einer sichtbaren Ausgabe auf der gleichen Ansicht ändern (etwa über einen geänderten Status). Beispiele sind Checkboxen, Radio-Inputs, Auswahllisten, Umschalter.
+Der Prüfschritt ist anwendbar, wenn die Ansicht interaktive Bedienelemente hat, die durch Eingaben von Nutzenden ihren Wert ändern können oder den Wert einer sichtbaren Ausgabe auf der gleichen Ansicht ändern (etwa über einen geänderten Status).
 
 === 2. Prüfung
 


### PR DESCRIPTION
Ergänzt eigentlich nur die Prüfung bezügl "Value" bei 9.4.1.2.

 Ein ggf. sinnvoller Unterschied wäre hier, dass geprüft wird, ob es direkt nach Eingabe zur Ausgabe geänderter Werte kommt oder ob man das Element neu fokussieren müsste, um den geänderten Wert ausgegeben zu bekommen - dann wäre das hier ein FAIL. Ob das wirklich intendiert ist hier, da bin ich mir nicht so sicher...