### PR TITLE
Update 5.9 Gleichzeitige Benutzerhandlungen.adoc

### DIFF
--- a/Prüfschritte/de/5.9 Gleichzeitige Benutzerhandlungen.adoc
+++ b/Prüfschritte/de/5.9 Gleichzeitige Benutzerhandlungen.adoc
@@ -29,7 +29,7 @@ Menschen mit motorischen Einschränkungen haben oft Probleme, mehrere Aktionen z
 == Wie wird das geprüft?
 
 === 1. Anwendbarkeit des Prüfschritts
-Der Prüfschritt ist immer anwendbar. Das Ergebnis ist ggf. aus Prüfschritt 11.2.5.1 "Alternativen für komplexe Zeiger-Gesten" übertragen. Bezüglich Tastasturbedienung wir dieser Prüfschritt nicht geprüft, da Einstellungsmöglichkeiten der Einfingerbedienung Aufgabe des Betriebssystems sind und nicht auf der Ebene der App implementiert werden sollten. Lücken in der Unterstützung sind als Mangel der Betriebssytemumgebung zu bewerten, die App-Entwickler nicht kompensieren können.
+Der Prüfschritt ist immer anwendbar. Bezüglich Tastasturbedienung wir dieser Prüfschritt nicht geprüft, da Einstellungsmöglichkeiten für Einfingerbedienung (etwa Microsofts Einrastfunktion) Aufgabe des Betriebssystems sind und nicht auf der Ebene der App implementiert werden sollten. Lücken in der Unterstützung sind als Mangel der Betriebssytemumgebung zu bewerten, die App-Entwickler nicht kompensieren können.
 
 === 2. Prüfung
 Wenn die Accessibility Baseline Umgebungen einschließt, die bei Tastaturnutzung keine Einfingerbedienung anbietet (Android):

--- a/Prüfschritte/de/5.9 Gleichzeitige Benutzerhandlungen.adoc
+++ b/Prüfschritte/de/5.9 Gleichzeitige Benutzerhandlungen.adoc
@@ -40,7 +40,7 @@ Wenn die Accessibility Baseline Umgebungen einschließt, die bei Tastaturnutzung
 . Bedienung mit Toucheingabe überprüfen. Sind alle Funktionen mit Einfinger-Gesten aktivierbar, ohne das gleichzeitig Gerätetasten gedrückt oder das Gerät bewegt bzw. ausgerichtet werden muss?
 
 === 3. Hinweise
-Ggf. sind bei Touchbedienung außer dem gleichzeitigen Drücken von Gerätetasten oder der Ausrichtuing des Geräts andere, hier nicht näher spezifizierte simultane Aktionen denkbar, die für die erfolgreiche Bedienuung ausgeführt werden müssten, etwa die Auswertung von Handbewegungen über dem Gerät, der Auswertung des Kamera-Bildes, wofür das Gerät gehalten bzw. bewegt werden müsste, usw.
+Ggf. sind bei Touchbedienung außer dem gleichzeitigen Drücken von Gerätetasten oder der Ausrichtung des Geräts andere, hier nicht näher spezifizierte simultane Aktionen denkbar, die für die erfolgreiche Bedienuung ausgeführt werden müssten, etwa die Auswertung von Handbewegungen über dem Gerät, der Auswertung des Kamera-Bildes, wofür das Gerät gehalten bzw. bewegt werden müsste, usw.
 
 === 4. Bewertung
 

--- a/Prüfschritte/de/5.9 Gleichzeitige Benutzerhandlungen.adoc
+++ b/Prüfschritte/de/5.9 Gleichzeitige Benutzerhandlungen.adoc
@@ -43,7 +43,7 @@ Ggf. sind bei Touchbedienung außer dem gleichzeitigen Drücken von Gerätetaste
 === 4. Bewertung
 
 ==== Erfüllt
-* Wenn die Accessibility Baseline Umgebungen einschließt, die bei Tastaturnutzung keine Einfingerbedienung anbieten, sind bei Touchbedienung alle Funktionen der App über Einfinger-Gesten aktivierbar.
+* Bei Touchbedienung sind alle Funktionen der App über einfache Zeigeraktionen aktivierbar.
 
 == Einordnung des Prüfschritts
 

--- a/Prüfschritte/de/5.9 Gleichzeitige Benutzerhandlungen.adoc
+++ b/Prüfschritte/de/5.9 Gleichzeitige Benutzerhandlungen.adoc
@@ -29,9 +29,7 @@ Menschen mit motorischen Einschränkungen haben oft Probleme, mehrere Aktionen z
 == Wie wird das geprüft?
 
 === 1. Anwendbarkeit des Prüfschritts
-Der Prüfschritt ist immer anwendbar, wenn die Accessibility Baseline Umgebungen einschließt, die bei Tastaturnutzung keine Einfingerbedienung anbieten (z.B. Android). Das Ergebnis ist ggf. aus Prüfschritt 11.2.5.1 "Alternativen für komplexe Zeiger-Gesten" übertragen.
-
-Bezüglich Tastasturbedienung wir dieser Prüfschritt nicht geprüft, da Einstellungsmöglichkeiten der Einfingerbedienung Aufgabe des Betriebssystems sind und nicht auf der Ebene der App implementiert werden sollten. Lücken in der Unterstützung sind als Mangel der Betriebssytemumgebung zu bewerten, die App-Entwickler nicht kompensieren können.
+Der Prüfschritt ist immer anwendbar. Das Ergebnis ist ggf. aus Prüfschritt 11.2.5.1 "Alternativen für komplexe Zeiger-Gesten" übertragen. Bezüglich Tastasturbedienung wir dieser Prüfschritt nicht geprüft, da Einstellungsmöglichkeiten der Einfingerbedienung Aufgabe des Betriebssystems sind und nicht auf der Ebene der App implementiert werden sollten. Lücken in der Unterstützung sind als Mangel der Betriebssytemumgebung zu bewerten, die App-Entwickler nicht kompensieren können.
 
 === 2. Prüfung
 Wenn die Accessibility Baseline Umgebungen einschließt, die bei Tastaturnutzung keine Einfingerbedienung anbietet (Android):


### PR DESCRIPTION
Es gab einen unklaren Satz, der die Anwendbarkeit auf Android einzugrenzen schien (da hier keine Möglichkeit wie bei Windows eine Einrastfunktion auszuwählen, um Mehrfach-Tastendruck mit Einzeltastendruck durchzuführen). Da die Prüfung aber vor allem auf Multitouch-Gesten abzielt, ist der Prüfschritt immer anwendbar.

