### PR TITLE
5.5.1 Möglichkeiten der Bedienung: Ergänzung Aktionen bei Nutzung des…

### DIFF
--- a/Prüfschritte/de/5.5.1 Möglichkeiten der Bedienung.adoc
+++ b/Prüfschritte/de/5.5.1 Möglichkeiten der Bedienung.adoc
@@ -14,10 +14,23 @@ Menschen mit motorischen Einschränkungen sollen physische Informations- und Kom
 
 === 1. Anwendbarkeit des Prüfschritts
 
-Der Prüfschritt ist anwendbar, wenn die zu prüfende App zusammen mit physischem Zubehör genutzt wird und dieses Szenario geprüft wird. Beispiele für physisches Zubehör wären etwa ein Handscanner oder ein Kartenlesegerät zur Authentifizierung.
+Der Prüfschritt ist vor allem anwendbar, 
+wenn die zu prüfende App zusammen mit physischem Zubehör genutzt wird
+und dieses Szenario geprüft wird. 
+Beispiele für physisches Zubehör wären etwa ein Handscanner 
+oder ein Kartenlesegerät zur Authentifizierung.
+
+Der Prüfschritt ist auch anwendbar, wenn die Nutzung der App 
+die Bedienung physischer Tasten oder Regler am Gerät (etwa Smartphone oder Tablet) einschließt 
+oder dieses für bestimmte Formen der Eingabe gegriffen 
+und dann gedreht, geschüttelt oder anders ausgerichtet werden kann.
 
 === 2. Prüfung
-. Prüfen, ob während der Nutzung des Zubehörs  bei der Bedienung phyischer Teile (etwa Schalter, Regler oder Drehknöpfe) ein physisches Greifen, ein Zusammendrücken, oder eine Drehung des Handgelenks erforderlich sind.
+. Prüfen, ob für die Nutzung des Geräts z.B. für bestimmte Eingaben, ein physisches Greifen, ein Zusammendrücken, 
+oder eine Drehung des Handgelenks vorgesehen ist.
+. Prüfen ob für die Nutzung von Zubehör, z.B. bei der Bedienung phyischer Teile 
+(etwa Schalter, Regler oder Drehknöpfe) ein physisches Greifen, ein Zusammendrücken, 
+oder eine Drehung des Handgelenks vorgesehen sind.
 . Falls ja: Gibt es für den Prozess eine alternative Bedienmethode ohne diese Aktionen?
 
 === 3. Hinweise
@@ -34,12 +47,13 @@ Der Prüfschritt ist anwendbar, wenn die zu prüfende App zusammen mit physische
 == Einordnung des Prüfschritts
 
 === Abgrenzung von anderen Prüfschritten
-In diesem Prüfschritt geht es um die Bedienbarkeit von zusätzlichem Zubehör durch Menschen mit motorischen Einschränkungen, wenn dieses zusammen mit der App genutzt wird. Wenn die Anforderung so interpretiert wird, dass auch virtuelle Bedienelemente gemeint sind, so ist die Prüfung der Bedienbarkeit von diesen schon über verschiedene andere Prüfschritte der En abgedeckt, besonders durch:
+In diesem Prüfschritt geht es um die Bedienbarkeit von zusätzlichem Zubehör durch Menschen mit motorischen Einschränkungen, wenn dieses zusammen mit der App genutzt wird. Wenn die Anforderung so interpretiert wird, dass auch virtuelle Bedienelemente gemeint sind, so ist die Prüfung der Bedienbarkeit von diesen schon über verschiedene andere Prüfschritte abgedeckt, besonders durch:
 
 * 11.2.1.1 Tastatur
 * 11.2.1.4 Tastatur-Kurzbefehle abschaltbar oder anpassbar
 * 11.2.5.1 Alternativen für komplexe Zeigergesten
 * 11.2.5.2 Zeigergesten-Eingaben können abgebrochen oder widerrufen werden
+* 11.2.5.4 Betätigung durch Bewegung
 
 === Einordnung des Prüfschritts nach EN 301 549 V3.2.1
 

--- a/Prüfschritte/de/5.5.1 Möglichkeiten der Bedienung.adoc
+++ b/Prüfschritte/de/5.5.1 Möglichkeiten der Bedienung.adoc
@@ -25,11 +25,9 @@ die Bedienung physischer Tasten oder Regler am Gerät (etwa Smartphone oder Tabl
 oder das Gerät selbst für bestimmte Formen der Eingabe gegriffen, gedreht, geschüttelt oder anders ausgerichtet werden kann.
 
 === 2. Prüfung
-. Prüfen, ob für die Nutzung des Geräts z.B. für bestimmte Eingaben, ein physisches Greifen, ein Zusammendrücken, 
-oder eine Drehung des Handgelenks vorgesehen ist.
-. Prüfen ob für die Nutzung von Zubehör, z.B. bei der Bedienung phyischer Teile 
-(etwa Schalter, Regler oder Drehknöpfe) ein physisches Greifen, ein Zusammendrücken, 
-oder eine Drehung des Handgelenks vorgesehen sind.
+. Prüfen, ob bei die Nutzung der App, z.B. für bestimmte Eingaben, die Bedienung physischer Tasten oder Regler am Gerät oder die Manipulation des Geräts selbst vorgesehen ist, und dabei ein physisches Greifen, ein Zusammendrücken, oder eine Drehung des Handgelenks erforderlich ist.
+. Prüfen, ob bei der Nutzung von Zubehör, z.B. bei der Bedienung phyischer Teile wie Schalter, Regler oder Drehknöpfe, ein physisches Greifen, ein Zusammendrücken, 
+oder eine Drehung des Handgelenks verforderlich sind.
 . Falls ja: Gibt es für den Prozess eine alternative Bedienmethode ohne diese Aktionen?
 
 === 3. Hinweise
@@ -40,13 +38,13 @@ oder eine Drehung des Handgelenks vorgesehen sind.
 === 4. Bewertung
 
 ==== Erfüllt:
-* Zur Nutzung des Zubehörs sind physisches Greifen, Zusammendrücken, und eine Drehung des Handgelenks nicht erforderlich.
-*  Es gibt eine barrierefreie Alternative, alle erforderliche Aktionen zur Nutzung der App mit Zubehör ohne die physischen Aktionen (Greifen, Zusammendrückenm Drehung des Handgelenks) auszuführen.
+* Zur Nutzung der App bzw. des Zubehörs sind physisches Greifen, Zusammendrücken, oder eine Drehung des Handgelenks nicht erforderlich.
+*  Es gibt eine barrierefreie Alternative, alle für die Nutzung der App oder des Zubehörs erforderlichen Funktionen lassen sich ohne die genannten physischen Aktionen (Greifen, Zusammendrücken, Drehung des Handgelenks) ausführen.
 
 == Einordnung des Prüfschritts
 
 === Abgrenzung von anderen Prüfschritten
-In diesem Prüfschritt geht es um die Bedienbarkeit von zusätzlichem Zubehör durch Menschen mit motorischen Einschränkungen, wenn dieses zusammen mit der App genutzt wird. Wenn die Anforderung so interpretiert wird, dass auch virtuelle Bedienelemente gemeint sind, so ist die Prüfung der Bedienbarkeit von diesen schon über verschiedene andere Prüfschritte abgedeckt, besonders durch:
+In diesem Prüfschritt geht es um die Bedienbarkeit von physischen Geräten und zusätzlichem Zubehör mit physischen Bedienelementen durch Menschen mit motorischen Einschränkungen. Wenn die Anforderung so interpretiert wird, dass auch virtuelle Bedienelemente gemeint sind, so ist die Prüfung der Bedienbarkeit von diesen schon über verschiedene andere Prüfschritte abgedeckt, besonders durch:
 
 * 11.2.1.1 Tastatur
 * 11.2.1.4 Tastatur-Kurzbefehle abschaltbar oder anpassbar

--- a/Prüfschritte/de/5.5.1 Möglichkeiten der Bedienung.adoc
+++ b/Prüfschritte/de/5.5.1 Möglichkeiten der Bedienung.adoc
@@ -26,8 +26,8 @@ oder das Gerät selbst für bestimmte Formen der Eingabe gegriffen, gedreht, ges
 
 === 2. Prüfung
 . Prüfen, ob bei die Nutzung der App, z.B. für bestimmte Eingaben, die Bedienung physischer Tasten oder Regler am Gerät oder die Manipulation des Geräts selbst vorgesehen ist, und dabei ein physisches Greifen, ein Zusammendrücken, oder eine Drehung des Handgelenks erforderlich ist.
-. Prüfen, ob bei der Nutzung von Zubehör, z.B. bei der Bedienung phyischer Teile wie Schalter, Regler oder Drehknöpfe, ein physisches Greifen, ein Zusammendrücken, 
-oder eine Drehung des Handgelenks verforderlich sind.
+. Prüfen, ob bei der Nutzung von Zubehör, z.B. bei der Bedienung physischer Bestandteile wie Schalter, Regler oder Drehknöpfe, ein physisches Greifen, ein Zusammendrücken, 
+oder eine Drehung des Handgelenks erforderlich sind.
 . Falls ja: Gibt es für den Prozess eine alternative Bedienmethode ohne diese Aktionen?
 
 === 3. Hinweise

--- a/Prüfschritte/de/5.5.1 Möglichkeiten der Bedienung.adoc
+++ b/Prüfschritte/de/5.5.1 Möglichkeiten der Bedienung.adoc
@@ -22,8 +22,7 @@ oder ein Kartenlesegerät zur Authentifizierung.
 
 Der Prüfschritt ist auch anwendbar, wenn die Nutzung der App 
 die Bedienung physischer Tasten oder Regler am Gerät (etwa Smartphone oder Tablet) einschließt 
-oder dieses für bestimmte Formen der Eingabe gegriffen 
-und dann gedreht, geschüttelt oder anders ausgerichtet werden kann.
+oder das Gerät selbst für bestimmte Formen der Eingabe gegriffen, gedreht, geschüttelt oder anders ausgerichtet werden kann.
 
 === 2. Prüfung
 . Prüfen, ob für die Nutzung des Geräts z.B. für bestimmte Eingaben, ein physisches Greifen, ein Zusammendrücken, 


### PR DESCRIPTION
Bislang bezogen auf gekoppeltes Zubehör (Scanner, Kartenlesegeräte), nun auch bezogen auf Aktionen, die Eingaben an physischen Bedienelementen des Geräts oder die Manipulation des Geräts selbst vorsehen.

Die Fragestellung in Issue https://github.com/BIK-BITV/BIK-App-Test/issues/135 (sind mit "operable parts" auch virtuelle Bedienelemente auf dem Bildschirm gemeint?) ist noch nicht abschließend geklärt und ist deshalb hier nicht berücksichtigt.