### PR TITLE
11.1.1.1a Nicht-Text-Inhalt – Bedienelemente: Anpassungen im Text

### DIFF
--- a/Prüfschritte/de/11.1.1.1a Nicht-Text-Inhalt – Bedienelemente.adoc
+++ b/Prüfschritte/de/11.1.1.1a Nicht-Text-Inhalt – Bedienelemente.adoc
@@ -4,13 +4,15 @@ include::include/attributes.adoc[]
 
 == Was wird geprüft?
 
-Grafische Bedienelemente müssen Textalternativen haben. Textalternativen für  Schaltflächen oder interaktive Vorschaubilder sollen deren Aktion bzw. Ziel bezeichnen.
+Grafische Bedienelemente müssen Alternativtexte haben. Alternativtexte für Schaltflächen oder interaktive Vorschaubilder sollen deren Aktion bzw. Ziel bezeichnen.
 
 == Warum wird das geprüft?
 
-Für Screenreader-Nutzende sind Grafiken nicht zugänglich. Die Textalternative tritt dann an die Stelle der Grafik, sie soll die Grafik ersetzen und bei Bedienelementen das Linkziel bzw. die ausführbare Aktion bezeichnen.
+Für Screenreader-Nutzende sind Grafiken nicht zugänglich. Der Alternativtext tritt dann an die Stelle der Grafik, sie soll die Grafik ersetzen und bei Bedienelementen das Linkziel bzw. die ausführbare Aktion bezeichnen.
 
-Entwicklerinnen und Entwickler müssen Grafiken mit passenden Text ergänzen, damit Hilfsmittelsoftware den Text anstelle der Grafik z.B. in Braille und Sprache ausgeben kann. Das UI-Element wird dabei um ein Accessibility-Label ergänzt.
+Entwicklerinnen und Entwickler müssen Grafiken mit passenden Text ergänzen, damit Hilfsmittelsoftware den Text anstelle der Grafik z.B. in Braille und Sprache ausgeben kann. Für das Bedienelement wird dabei ein programmatisch zugänglicher Name als Alternativtext hinterlegt.
+
+Ist eine Grafik in ein Bedienelement eingeschlossen, dessen Linktext bzw. dessen hinterlegte Beschriftung das Linkziel bzw. die Funktion bereits ausreichend beschreibt, sollte das Bild aus der programmatischen Ausgabe durch geeignete Mittel entfernt werden.
 
 == Wie wird geprüft?
 
@@ -22,7 +24,7 @@ Der Prüfschritt ist anwendbar, wenn Grafiken als Bedienelemente (z.B., Icons in
 
 Falls ein Bedienelement aus einer (Symbol-)Grafik sowie einem Text besteht, der den Zweck des Bedienelements wiedergibt, dann gilt dieser Text als Alternative für die Grafik. Es ist dann ggf. sinnvoll, die Grafik selbst mit einer geeigneten Technik für Screenreader zu verstecken.
 
-Handelt es sich dabei um eine Grafik ohne visuell sichtbaren Text (alleinstehendes Icon oder Symbol), so sollte eine Textalternative vorhanden sein, die das Ziel bzw. die Aktion, die ausgeführt wird, beschreibt. In der Praxis ist dies Text, der über ein Accessibility-Label bereitgestellt wird.
+Handelt es sich dabei um eine Grafik ohne visuell sichtbaren Text (alleinstehendes Icon oder Symbol), so sollte ein Alternativtext vorhanden sein, der das Ziel bzw. die Aktion, die ausgeführt wird, beschreibt. In der Praxis ist dies Text, der über ein Accessibility-Label bereitgestellt wird.
 
 ==== 2.1 Prüfung von Textalternativen
 
@@ -30,30 +32,30 @@ Für eine Prüfung mit VoiceOver / iOS müssen die AI/OCR-Erkennungsfunktionen a
 
 . App mit zu prüfender Ansicht öffnen.
 . Screenreader starten und Fokus mit Hilfe der horizontalen Wischgeste auf jedes grafische Bedienelement setzen.
-. Prüfen, ob für die Bedienelemente Textalternativen ausgegeben werden und diese (auch) das Ziel bzw. die Funktion des Bedienelements beschreiben.
+. Prüfen, ob für jedes grafische Bedienelement ein Alternativtext ausgegeben wird und dieser das Ziel bzw. die Funktion des Bedienelements beschreibt.
 . Falls die Grafik zusammen mit aussagekräftigem Text als Bedienelement auftaucht, prüfen, ob die Grafik vor dem Screenreader versteckt wird (keine unnötigen und redundanten Ausgaben durch den Screenreader aufgrund der Grafik). 
 . Bei aktivierbaren informationstragenden Grafiken wird der Inhalt benannt und Linkziel bzw. Aktion beschrieben (etwa: "Porträtfoto Helga Müller - öffnet vergrößerte Ansicht").
 
 ==== 2.2 Gleichwertige (äquivalente) Alternativtexte
 
-Entscheidend ist: die App soll benutzbar sein, wenn Grafiken, oder Bilder oder Objekte durch die entsprechenden Textalternativen ersetzt sind.
+Entscheidend ist: die App soll benutzbar sein, wenn Grafiken, Bilder oder Objekte durch die entsprechenden Alternativtexte ersetzt sind.
 
 In der Regel bedeutet das:
 
-* Bei Schriftgrafiken soll die Textalternative den Text der Schriftgrafik wiederholen.
-* Bei Symbolen soll die Textalternative das Symbol nicht beschreiben, sondern ersetzen. Also zum Beispiel die Textalternative "Suchen" für ein Lupen-Symbol, das einen Dialog mit Sucheingabefeld öffnet.
+* Bei Schriftgrafiken soll der Alternativtext den Text der Schriftgrafik wiederholen.
+* Bei Symbolen soll der Alternativtext das Symbol nicht beschreiben, sondern ersetzen. Also zum Beispiel den Alternativtext "Suchen" für ein Lupen-Symbol, das einen Dialog mit Sucheingabefeld öffnet.
 
 Bei verlinkten Abbildungen gibt es folgende Möglichkeiten:
 
-* Der abgebildete Gegenstand wird in der Textalternative beschrieben (wenn der abgebildete Gegenstand wichtig ist und daraus das Linkziel hervorgeht, zum
+* Der abgebildete Gegenstand wird im Alternativtext beschrieben (wenn der abgebildete Gegenstand wichtig ist und daraus das Linkziel hervorgeht, zum
   Beispiel Logo).
-* Das Ziel des Links wird über die Textalternative vermittelt.
-* Der abgebildete Gegenstand und das Ziel des Links bzw. die Aktion werden über die Textalternative vermittelt (wenn beides wichtig ist).
+* Das Ziel des Links wird über den Alternativtext vermittelt.
+* Der abgebildete Gegenstand und das Ziel des Links bzw. die Aktion werden über den Alternativtext vermittelt (wenn beides wichtig ist).
 
 Generell gilt:
 
-* Textalternativen sollen kurz sein.
-* Ausführliche Beschreibungen von Abbildungen sollen nicht in die Textalternative, sondern im Kontext der Abbildung zur Verfügung gestellt werden (etwa direkt darunter, in einem Ausklappbereich, oder auch in einem Link zu einer Ansicht, die die Alternative enthält).
+* Alternativtexte sollen kurz sein.
+* Ausführliche Beschreibungen von Abbildungen sollen nicht im Alternativtext, sondern im Kontext der Abbildung zur Verfügung gestellt werden (etwa direkt darunter, in einem Ausklappbereich, oder auch in einem Link zu einer Ansicht, die die Alternative enthält).
 
 === 3. Hinweise
 
@@ -69,8 +71,7 @@ Bei Schriftgrafiken sollte die Assistenz darauf achten, dass sichtbarer Text und
 
 ==== Nicht voll erfüllt:
 
-* Die Textalternative fehlt bei einem für die Benutzung der App weniger wichtigen Bedienelement.
-* Textalternativen sind missverständlich, undeutlich oder extrem lang.
+* Textalternativen sind missverständlich, redundant, oder extrem lang.
 
 ==== Nicht erfüllt:
 


### PR DESCRIPTION
* Vereinheitlichung auf "Alternativtext" statt "Textalternative"
* Entfernen eines Hinweises auf weniger wichtige Bedienelemente unter "Bewertung: nicht voll erfüllt"