### PR TITLE
11.1.4.11 Nicht-Text-Kontrast: Kontrast der Fokushervorhebung

### DIFF
--- a/Prüfschritte/de/11.1.4.11 Nicht-Text-Kontrast.adoc
+++ b/Prüfschritte/de/11.1.4.11 Nicht-Text-Kontrast.adoc
@@ -29,7 +29,6 @@ Nicht anwendbar ist der Prüfschritt auf Fotos, Logos, Flaggen, Screenshots, Dia
 Ebenfalls nicht anwendbar ist der Prüfschritt auf inaktive Bedienelemente, also solche, die zustandsabhängig für die Interaktion nicht zur Verfügung stehen.
 
 Eine Ausnahme gilt für native Bedienelemente wie iOS toggle switches, da hier die _platform software_ (also das mobile Betriebssystem) für den Browser (_user agent_) steht, für dessen unveränderte Darstellung von Bedienelementen es in den Web-Anforderungen https://www.w3.org/TR/WCAG21/#x1-4-11-non-text-contrast[eine Ausnahme] gibt.
-Wir haben um Bestätigung dieser Position in einem bestehenden https://github.com/w3c/wcag2ict/issues/82[Issue bei der WCAG2ICT Taskforce] gebeten.
 
 === 2. Prüfung
 

--- a/Prüfschritte/de/11.1.4.11 Nicht-Text-Kontrast.adoc
+++ b/Prüfschritte/de/11.1.4.11 Nicht-Text-Kontrast.adoc
@@ -67,6 +67,10 @@ Wenn bei grafischen Bedienelementen mit nebenstehendem Text der Textkontrast nic
 . Informationstragende Grafiken identifizieren, bei denen die Information nur über die Grafik und nicht (oder nicht ausreichend) über beigefügten Text vermittelt wird.
 . Wenn es in Bereichen der Grafik Farbverläufe gibt, Anteile mit einem Kontrast von weniger als 3:1 ignorieren und bewerten, ob die Information immer noch ausreichend vom kontrastreicheren Teil der Grafik vermittelt wird.
 
+==== Prüfung des Kontrastes der Tastaturfokus-Hervorhebung
+. Wo der Tastaturfokus durch Farbwechsel hervorgehoben wird, prüfen, ob der Kontrast zum Hintergrund mindestens 3:1 beträgt.
+. Die Standard iOS und Android Tastaturfokus-Hervorhebung (hellgraue oder hellblaue Einfärbung des Hintergrunds) ist aufgrund der Ausnahme in der WCAG-Anforderung 1.4.11 ("except for inactive components or where the appearance of the component is determined by the user agent and not modified by the author") als ausreichend zu bewerten.
+
 === 3. Hinweise
 
 ==== 3.1 Zur Identifizierung von nativen Bedienelementen, die von der Anforderung ausgenommen sind

--- a/Prüfschritte/de/11.1.4.11 Nicht-Text-Kontrast.adoc
+++ b/Prüfschritte/de/11.1.4.11 Nicht-Text-Kontrast.adoc
@@ -67,8 +67,8 @@ Wenn bei grafischen Bedienelementen mit nebenstehendem Text der Textkontrast nic
 . Informationstragende Grafiken identifizieren, bei denen die Information nur über die Grafik und nicht (oder nicht ausreichend) über beigefügten Text vermittelt wird.
 . Wenn es in Bereichen der Grafik Farbverläufe gibt, Anteile mit einem Kontrast von weniger als 3:1 ignorieren und bewerten, ob die Information immer noch ausreichend vom kontrastreicheren Teil der Grafik vermittelt wird.
 
-==== Prüfung des Kontrastes der Tastaturfokus-Hervorhebung
-. Wo der Tastaturfokus durch Farbwechsel hervorgehoben wird, prüfen, ob der Kontrast zum Hintergrund mindestens 3:1 beträgt.
+==== 2.4 Prüfung des Kontrastes der Tastaturfokus-Hervorhebung
+. Wo der Tastaturfokus durch Farbwechsel von Elementen hervorgehoben wird (etwa bei Schaltern oder Icons), prüfen, ob der Kontrast des fokussierten Elements zum Hintergrund mindestens 3:1 beträgt.
 . Die Standard iOS und Android Tastaturfokus-Hervorhebung (hellgraue oder hellblaue Einfärbung des Hintergrunds) ist aufgrund der Ausnahme in der WCAG-Anforderung 1.4.11 ("except for inactive components or where the appearance of the component is determined by the user agent and not modified by the author") als ausreichend zu bewerten.
 
 === 3. Hinweise


### PR DESCRIPTION
* Hinzufügung der Bewertung des Kontrasts selbstgestalteter Tastaturfokus-Hervorhebung durch Ändern der Farbe (etwa Hintergundfarbe von Schaltern)
* Hinzufügung des Hinweises, dass der unveränderte Tastaturfokus-Hervorhebung von iOS und Android wegen der Ausnahme in 1.4.11 Non-text contrast als ausreichend bewertet werden muss