### PR TITLE
11.2.4.7 Fokus sichtbar: Änderung der Bewertung, Hinweis auf iOS Fokuskontrasteinstellungen

### DIFF
--- a/Prüfschritte/de/11.2.4.7 Fokus sichtbar.adoc
+++ b/Prüfschritte/de/11.2.4.7 Fokus sichtbar.adoc
@@ -56,7 +56,7 @@ Der Screenreader-Fokus sollte bei der Beurteilung der Tastaturfokus-Hervorhebung
 
 ==== Erfüllt:
 * Wird nur die native Fokushervorhebung genutzt, ist der Prüfschritt auch erfüllt, wenn die Hervorhebung schwach ist (z.B. hellgraue oder hellblaue Einfärbung), der Kontrast also unter 3:1 liegt.
-* Wird eien vom Entwickler definierte Hervorhebung eingesezt, soll diese einen Kontrast zum Hintergrund von mindestens 3:1 erfüllen. Bewertet wird dies jedoch im Prüfschritt 11.1.4.11 Nicht-Text Kontrast. Wird eine Hervorhebung nur über Änderung der Farbe ungesetzt, ist dies zusätzlich im Prüfschritt 9.1.4.1 Ohne Farben nutzbar zu prüfen und zu bewerten.
+* Wird eien vom Entwickler definierte Hervorhebung eingesezt, soll diese einen Kontrast zum Hintergrund von mindestens 3:1 erfüllen. Bewertet wird dies jedoch im Prüfschritt <<11.1.4.11 Nicht-Text-Kontrast.adoc#,11.1.4.11 Nicht-Text Kontrast>>. Wird eine Hervorhebung nur über Änderung der Farbe ungesetzt, ist dies zusätzlich im Prüfschritt <<11.1.4.1 Benutzung von Farbe.adoc#,11.1.4.1 Benutzung von Farbe>> zu prüfen und zu bewerten.
 
 ==== Nicht erfüllt
 * Der Prüfschritt ist nicht erfüllt, wenn auf einem interaktiven Element überhaupt kein Tastaturfokus sichtbar ist. 

--- a/Prüfschritte/de/11.2.4.7 Fokus sichtbar.adoc
+++ b/Prüfschritte/de/11.2.4.7 Fokus sichtbar.adoc
@@ -56,7 +56,7 @@ Der Screenreader-Fokus sollte bei der Beurteilung der Tastaturfokus-Hervorhebung
 
 ==== Erfüllt:
 * Wird nur die native Fokushervorhebung genutzt, ist der Prüfschritt auch erfüllt, wenn die Hervorhebung schwach ist (z.B. hellgraue oder hellblaue Einfärbung), der Kontrast also unter 3:1 liegt.
-* Wird eine Entwickler-definierte Hervorhebung (etwa Änderung der Farbe bei Fokuserhalt) eingesetzt, soll der Kontrast zum Hintergrund und zum nicht fokussierten Zustand mindestens 3:1 betragen. Bewertet wird dies im Prüfschritt 11.1.4.11 Nicht-Text Kontrast.
+* Wird eien vom Entwickler definierte Hervorhebung eingesezt, soll diese einen Kontrast zum Hintergrund von mindestens 3:1 erfüllen. Bewertet wird dies jedoch im Prüfschritt 11.1.4.11 Nicht-Text Kontrast. Wird eine Hervorhebung nur über Änderung der Farbe ungesetzt, ist dies zusätzlich im Prüfschritt 9.1.4.1 Ohne Farben nutzbar zu prüfen und zu bewerten.
 
 ==== Nicht erfüllt
 * Der Prüfschritt ist nicht erfüllt, wenn auf einem interaktiven Element überhaupt kein Tastaturfokus sichtbar ist. 

--- a/Prüfschritte/de/11.2.4.7 Fokus sichtbar.adoc
+++ b/Prüfschritte/de/11.2.4.7 Fokus sichtbar.adoc
@@ -24,11 +24,8 @@ Wenn eine App ausschließlich per Tastatur bedient wird, muss das fokussierte Be
 Die von mobilen Betriebssystemen vorgesehene Standard-Kennzeichnung des Tastaturfokus ist oft nicht gut sichtbar:
 
 === iOS
-* Die Standard-Hervorhebung von über Tabulator erreichbaren Bereichen ist recht gut (deutlicher farbiger Rahmen),
-bei über Pfeiltasten erreichbaren Einträgen innerhalb fokussierter Bereiche ist die Hervorhebung aber schlecht:
-hellblau auf weiß mit einem sehr geringen Kontrast von nur 1,2:1. 
-* In den Bedienungshilfen-Einstellungen von iOS lässt sich jedoch unter "Tastaturen und Texteingabe" > "Tastatursteuerung" die Option "Hoher Kontrast" einstellen. 
-Damit werden alle Elemente, die überhaupt den Tastaturfokus bekommen, sehr deulich über dicke schwarze Umrandung hervorgehoben. 
+* Die Standardhervorhebung für per Tabulator erreichbare Bereiche ist meist gut erkennbar (deutlicher farbiger Rahmen). Bei Einträgen, die innerhalb eines fokussierten Bereichs per Pfeiltasten navigiert werden, ist die Hervorhebung jedoch schlecht: hellblau auf weiß mit einem sehr geringen Kontrast von nur 1,2:1.
+* In den iOS-Bedienungshilfen unter "Tastaturen und Texteingabe" > "Tastatursteuerung" kann die Option "Hoher Kontrast" aktiviert werden. Dadurch erhalten alle Elemente mit Tastaturfokus eine gut sichtbare, dicke schwarze Umrandung.
 
 === Android
 * Die Standard-Hervrhebung ist hellgrau auf weiß oder ein leichte Abdunkelung auf Elementen mit egenem farbigen Hintergrund. Das Resultat ist ein sehr geringer Kontrast von etwa 1,2:1.

--- a/Prüfschritte/de/11.2.4.7 Fokus sichtbar.adoc
+++ b/Prüfschritte/de/11.2.4.7 Fokus sichtbar.adoc
@@ -27,16 +27,20 @@ Apps haben in den Standardeinstellungen eine zu schwache Fokushervorhebung.
 
 Die von mobilen Betriebssystemen vorgesehene Kennzeichnung des Tastaturfokus ist oft nicht gut sichtbar:
 
-* iOS: Die Standard-Hervorhebung von über Tabulator erreichbaren Bereichen ist recht gut (deutlicher blauer Rahmen),
+=== iOS
+* Die Standard-Hervorhebung von über Tabulator erreichbaren Bereichen ist recht gut (deutlicher farbiger Rahmen),
 bei über Pfeiltasten erreichbaren Einträgen innerhalb fokussierter Bereiche ist die Hervorhebung aber schlecht:
 hellblau auf weiß mit einem sehr geringen Kontrast von nur 1,2:1. 
-In den Bedienungshilfen-Einstellungen von iOS lässt sich jedoch unter "Tastaturen und Texteingabe" > "Tastatursteuerung" die Option "Hoher Kontrast" einstellen. 
+* In den Bedienungshilfen-Einstellungen von iOS lässt sich jedoch unter "Tastaturen und Texteingabe" > "Tastatursteuerung" die Option "Hoher Kontrast" einstellen. 
 Damit werden alle Elemente, die überhaupt den Tastaturfokus bekommen, sehr deulich über dicke schwarze Umrandung hervorgehoben. 
 
-* Android: Die Standard-Hervrhebung ist hellgrau auf weiß  mit einem sehr geringen Kontrast von nur 1,2:1.
+=== Android
+* Die Standard-Hervrhebung ist hellgrau auf weiß oder ein leichte Abdunkelung auf Elementen mit egenem farbigen Hintergrund. Das Resultat ist ein sehr geringer Kontrast von etwa 1,2:1.
 
-Der Kontrast zum nichtaktivierten Zustand des Elements sollte mindestens 3:1 betragen.
-Die schlechte native Fokushervorhebung sollte durch eine entsprechende Gestaltung des Fokusindikators korrigiert werden.
+Der Kontrast zum nichtaktivierten Zustand des Elements sollte mindestens 3:1 betragen. Diese wäre für nicht native Foushervorhebung (etwa wenn ein Entwicker-definierter Farbwechsel bei Fokussierung von Elementen stattfindet) bei mindestens 3:1 liegen. Die native, von Entwicklerin unveränderte Tastaturfokushervorhebung fällt dagegen unter eine Ausnahme im Erfolgskriterium 1.4.11 (Nicht-Text Kontrast) für native Elemente: "except for inactive components or where the appearance of the component is determined by the user agent and not modified by the author".
+
+Es wid also hier nur geprüft, ob überhaupt eine Fokushervorhebung bei Fokuserhalt sichtbar ist - nicht, ob diese ausreichend kontrastreich ist. Die Bewertung des Fokuskontrastes von entwicker-definierten Fokushervorhebungen fällt unter den Prüfschritt 11.1.4.11 Nicht-Text Kontrast.
+
 
 == Wie wird geprüft?
 
@@ -58,14 +62,7 @@ Versteckte Sprunglinks sollen bei Fokuserhalt eingeblendet werden.
 
 === 3. Hinweise
 ==== 3.1 Allgemeine Hinweise
-* Es kann davon ausgegangen werden, dass sehbehinderte Tastaturnutzende betriebssystemseitige Einstellungen zu verbesserten Darstellung des Tastaturfokus (wo vorhanden)  nutzen, wenn die Standardhervorhebung für sie nicht ausreichend ist. In iOS wird die Option "Hoher Kontrast" an der gleichen Stelle geboten, wo überhaupt die Tastatursteurung aktiviert wird.
-* Der Prüfschritt ist nicht erfüllt, wenn überhaupt kein Tastaturfokus sichtbar ist.
-Dann ist eventuell auch Prüfschritt
-ifdef::env_embedded[11.2.1.1 "Tastaturbedienung"]
-ifndef::env_embedded[]
-  <<11.2.1.1 Tastaturbedienung.adoc#,11.2.1.1 Tastaturbedienung>>
-endif::env_embedded[]
-nicht erfüllt.
+* Es kann davon ausgegangen werden, dass sehbehinderte Tastaturnutzende betriebssystemseitige Einstellungen zu verbesserten Darstellung des Tastaturfokus (wo vorhanden)  nutzen, wenn die Standardhervorhebung für sie nicht ausreichend ist. In iOS wird die Option "Hoher Kontrast" an der gleichen Stelle geboten, wo überhaupt die Tastatursteuerung aktiviert wird.
 
 ==== 3.1  Hinweise für die Team-Prüfung
 Der Screenreader-Fokus sollte bei der Beurteilung der Tastaturfokus-Hervorhebung nicht berücksichtigt werden. Die Prüfung erfolgt mit verbundener Tastatur und ausgeschaltetem Screenreader.
@@ -73,26 +70,17 @@ Der Screenreader-Fokus sollte bei der Beurteilung der Tastaturfokus-Hervorhebung
 === 4. Bewertung
 
 ==== Erfüllt:
+* Wird nur die native Fokushervorhebung genutzt, ist der Prüfschritt auch erfüllt, wenn die Hervorhebung schwach ist (z.B. hellgraue oder hellblaue Einfärbung), der Komntrast also unter 3:1 liegt.
+* Wird ein Entwickler-defineirte Hervorhaebung (etw aÄnderugn der Fabe bei Fokuserhalt) eongesetzt, soll der Kontrast zum Hintergrund und zum nicht fokussierten Zustand mindestens 3:1 betragen. Bewertet wird dies im Prüfdschritt 11.1.4.11 Nicht-Text Kontrast.
 
-Die Fokussierung interaktiver Elemente ist visuell wahrnehmbar:
-
-* Rahmen, Unterstreichung, Farbumkehr, Formänderungen oder zusätzliche Markierungen werden bei Tastaturfokussierung eingesetzt.
-
-* Wenn die Fokussierung von Links oder Buttons nur über die Änderung der Text- oder Hintergrundfarbe vermittelt wird, 
-beträgt deren Kontrastabstand zum unfokussierten Zustand mindestens 3:1.
-
-*  Wenn nur der System-Tastaturfokus angezeigt wird, ist dieser vor gestalteten Hintergründen ausreichend sichtbar, 
-er erfüllt den Prüfschritt
-ifdef::env_embedded[11.1.4.3 "Kontraste von Texten ausreichend".]
+==== Nicht erfüllt
+* Der Prüfschritt ist nicht erfüllt, wenn überhaupt kein Tastaturfokus sichtbar ist. 
+Dann ist eventuell auch Prüfschritt
+ifdef::env_embedded[11.2.1.1 "Tastaturbedienung"]
 ifndef::env_embedded[]
-  <<11.1.4.3 Kontraste von Texten ausreichend.adoc#,11.1.4.3 Kontraste von Texten
-  ausreichend>>.
+  <<11.2.1.1 Tastaturbedienung.adoc#,11.2.1.1 Tastaturbedienung>>
 endif::env_embedded[]
-
-==== Teilweise erfüllt oder schlechter:
-
-* Sprunglinks bleiben bei Fokuserhalt versteckt.
-* Der System-Fokus wird unterdrückt, bei Tastaturnutzung wird kein Fokus angezeigt.
+nicht erfüllt.
   
 == Quellen
 === Allgemein

--- a/Prüfschritte/de/11.2.4.7 Fokus sichtbar.adoc
+++ b/Prüfschritte/de/11.2.4.7 Fokus sichtbar.adoc
@@ -22,13 +22,15 @@ oder welches Element Ausgangspunkt einer Pfeiltasten-Auswahl wird (etwa bei tab 
 Wenn Apps allein durch die Tastatur bedient werden, 
 muss das fokussierte Bedienelement für den Nutzende deutlich hervorgehoben sein. 
 Eine Tastaturbedienung ist für visuelle Nutzer sonst kaum möglich.
+Apps haben in den Standardeinstellungen eine zu schwache Fokushervorhebung. 
+
 
 Die von mobilen Betriebssystemen vorgesehene Kennzeichnung des Tastaturfokus ist oft nicht gut sichtbar:
 
 * iOS: Die Standard-Hervorhebung von über Tabulator erreichbaren Bereichen ist recht gut (deutlicher blauer Rahmen),
 bei über Pfeiltasten erreichbaren Einträgen innerhalb fokussierter Bereiche ist die Hervorhebung aber schlecht:
-hellblau auf weiß mit einem sehr geringen Kontrast von nur 1,2:1.
-(Nach Auswahl von "Kontrast erhöhen" in den iOS Bedienungshifen verbessert sich der Kontrast nur sehr geringfügig auf 1,3:1.)
+hellblau auf weiß mit einem sehr geringen Kontrast von nur 1,2:1. In den Bedienungshilfen-Einstellungen von iOS lässt sich jedoch unter "Tastaturen und Texteingabe" > "Tastatursteuerung" die Option "Hoher Kontrast" einstellen. Damit werden alle Elemente, die überhaupt den Tastaturfokus bekommen, sehr deulich über dicke schwarze Umrandung hervorgehoben. 
+
 * Android: Die Standard-Hervrhebung ist hellgrau auf weiß  mit einem sehr geringen Kontrast von nur 1,2:1.
 
 Der Kontrast zum nichtaktivierten Zustand des Elements sollte mindestens 3:1 betragen.

--- a/Prüfschritte/de/11.2.4.7 Fokus sichtbar.adoc
+++ b/Prüfschritte/de/11.2.4.7 Fokus sichtbar.adoc
@@ -4,14 +4,16 @@ include::include/attributes.adoc[]
 
 == Was wird geprüft?
 
-Werden Bedienelementen mit der Tastatur fokussiert, 
-dann soll sich der Tastaturfokus-Indikator deutlich vom Hintergrund abheben (mindestens 3:1 Kontrastabstand).
-Der Fokus-Indikator muss außerdem einen Kontrastunterschied von mindestens 3:1 zwischen fokussiertem und nicht fokussiertem Zustand haben. 
-Meist ist das einfach der Kontrast zwischen dem Fokus-Indikator und dem Hintergrund. 
-Wenn jedoch die Fokussierung durch die Änderung der Farbe einer Schaltfläche angezeigt wird, 
-ist es der Kontrast zwischen der Farbe der Fläche im fokussierten und im nicht fokussierten Zustand. 
+Werden Bedienelementen mit der Tastatur fokussiert, dann soll es einen sichtbaren Tastaturfokus-Indikator geben.
+Es wird also in diesem Prüfschritt  nur geprüft, ob überhaupt eine Tastatur-Fokushervorhebung sichtbar ist - nicht, ob diese ausreichend kontrastreich ist. 
 
-Versteckte Sprunglinks sollen bei Fokuserhalt eingeblendet werden.
+Wenn Fokussierung durch eine Entwickler-gesteuerte Hervorhebung, z.B. die Änderung der Farbe einer Schaltfläche bei Fokussierung, angezeigt wird, 
+soll der Kontrast der Hervorhebung und der Kontrastunterschied zwischen fokussiertem und nicht fokussiertem Zustand mindestens 3:1 betragen. 
+Dies wird jedoch im Prüfschritt 11.1.4.11 Nicht-Text Kontrast bewertet.
+
+Wird eine unveränderte Systemfokushervorhebung durchgängig genutzt (meist eine farbiger Rahmen oder hellgraue oder hellblaue kontrastarme Einfärbung des Hintergrunds oder des Elements), gilt dieser Prüfschritt als erfüllt, denn bezüglich Kontrast gibt es eine Ausnahme im Erfolgskriterium 1.4.11 (Nicht-Text Kontrast) für native Elemente: "except for inactive components or where the appearance of the component is determined by the user agent and not modified by the author". Für Apps ist statt "user agent" das Betriebssystem (iOS oder Android) die zuständige Plattform.
+
+iOS bietet die Möglichkeit, die Fokushervorhebung durchgängig deutlich darzustellen ( Tastatursteuerung: Hoher Kontrast).
 
 == Warum wird das geprüft?
 
@@ -19,13 +21,10 @@ Für Tastaturbenutzende ist es wichtig, zu sehen, wo sich der Tastaturfokus gera
 welches Bedienelement also ausgelöst wird, wenn es aktiviert wird (z.B. über ENTER oder Leertaste) 
 oder welches Element Ausgangspunkt einer Pfeiltasten-Auswahl wird (etwa bei tab panels oder Auswahllisten).
 
-Wenn Apps allein durch die Tastatur bedient werden, 
-muss das fokussierte Bedienelement für den Nutzende deutlich hervorgehoben sein. 
+Wenn Apps allein durch die Tastatur bedient werden, muss das fokussierte Bedienelement hervorgehoben sein. 
 Eine Tastaturbedienung ist für visuelle Nutzer sonst kaum möglich.
-Apps haben in den Standardeinstellungen eine zu schwache Fokushervorhebung. 
 
-
-Die von mobilen Betriebssystemen vorgesehene Kennzeichnung des Tastaturfokus ist oft nicht gut sichtbar:
+Die von mobilen Betriebssystemen vorgesehene Standard-Kennzeichnung des Tastaturfokus ist oft nicht gut sichtbar:
 
 === iOS
 * Die Standard-Hervorhebung von über Tabulator erreichbaren Bereichen ist recht gut (deutlicher farbiger Rahmen),
@@ -36,10 +35,6 @@ Damit werden alle Elemente, die überhaupt den Tastaturfokus bekommen, sehr deul
 
 === Android
 * Die Standard-Hervrhebung ist hellgrau auf weiß oder ein leichte Abdunkelung auf Elementen mit egenem farbigen Hintergrund. Das Resultat ist ein sehr geringer Kontrast von etwa 1,2:1.
-
-Der Kontrast zum nichtaktivierten Zustand des Elements sollte mindestens 3:1 betragen. Diese wäre für nicht native Foushervorhebung (etwa wenn ein Entwicker-definierter Farbwechsel bei Fokussierung von Elementen stattfindet) bei mindestens 3:1 liegen. Die native, von Entwicklerin unveränderte Tastaturfokushervorhebung fällt dagegen unter eine Ausnahme im Erfolgskriterium 1.4.11 (Nicht-Text Kontrast) für native Elemente: "except for inactive components or where the appearance of the component is determined by the user agent and not modified by the author".
-
-Es wid also hier nur geprüft, ob überhaupt eine Fokushervorhebung bei Fokuserhalt sichtbar ist - nicht, ob diese ausreichend kontrastreich ist. Die Bewertung des Fokuskontrastes von entwicker-definierten Fokushervorhebungen fällt unter den Prüfschritt 11.1.4.11 Nicht-Text Kontrast.
 
 
 == Wie wird geprüft?
@@ -55,26 +50,22 @@ oder Verbindung über Bluetooth-Kopplung oder USB-Kabel anschließen.
 . Zu prüfende Ansicht der App öffnen.
 . Mit der Tabulatortaste zu allen interaktiven Elementen navigieren.
 Wo diese weitere Auswahlen zulassen, etwa bei Tabpanels, Menüs oder Auswahllisten, 
-mit den Pfeiltasten oder ggf. dem Tabulator zu Tabs bzw. Optionen navigieren.
+mit den Pfeiltasten oder ggf. dem Tabulator zu Tabs bzw. Optionen navigieren. Ggf. ist dazu auch die Eingabe von STRG + TAB oder STRG + SHIFT + TAB notwendig.
 . Prüfen, ob alle Elemente mit grafischen Veränderungen auf den Fokus reagieren 
 (zum Beispiel mit Farbwechseln, Unterstreichungen oder eingeblendeten Symbolen). 
-Versteckte Sprunglinks sollen bei Fokuserhalt eingeblendet werden.
+Versteckte Sprunglinks (wo vorhanden) sollen bei Fokuserhalt eingeblendet werden.
 
 === 3. Hinweise
-==== 3.1 Allgemeine Hinweise
-* Es kann davon ausgegangen werden, dass sehbehinderte Tastaturnutzende betriebssystemseitige Einstellungen zu verbesserten Darstellung des Tastaturfokus (wo vorhanden)  nutzen, wenn die Standardhervorhebung für sie nicht ausreichend ist. In iOS wird die Option "Hoher Kontrast" an der gleichen Stelle geboten, wo überhaupt die Tastatursteuerung aktiviert wird.
-
-==== 3.1  Hinweise für die Team-Prüfung
 Der Screenreader-Fokus sollte bei der Beurteilung der Tastaturfokus-Hervorhebung nicht berücksichtigt werden. Die Prüfung erfolgt mit verbundener Tastatur und ausgeschaltetem Screenreader.
 
 === 4. Bewertung
 
 ==== Erfüllt:
-* Wird nur die native Fokushervorhebung genutzt, ist der Prüfschritt auch erfüllt, wenn die Hervorhebung schwach ist (z.B. hellgraue oder hellblaue Einfärbung), der Komntrast also unter 3:1 liegt.
-* Wird ein Entwickler-defineirte Hervorhaebung (etw aÄnderugn der Fabe bei Fokuserhalt) eongesetzt, soll der Kontrast zum Hintergrund und zum nicht fokussierten Zustand mindestens 3:1 betragen. Bewertet wird dies im Prüfdschritt 11.1.4.11 Nicht-Text Kontrast.
+* Wird nur die native Fokushervorhebung genutzt, ist der Prüfschritt auch erfüllt, wenn die Hervorhebung schwach ist (z.B. hellgraue oder hellblaue Einfärbung), der Kontrast also unter 3:1 liegt.
+* Wird eine Entwickler-definierte Hervorhebung (etwa Änderung der Farbe bei Fokuserhalt) eingesetzt, soll der Kontrast zum Hintergrund und zum nicht fokussierten Zustand mindestens 3:1 betragen. Bewertet wird dies im Prüfschritt 11.1.4.11 Nicht-Text Kontrast.
 
 ==== Nicht erfüllt
-* Der Prüfschritt ist nicht erfüllt, wenn überhaupt kein Tastaturfokus sichtbar ist. 
+* Der Prüfschritt ist nicht erfüllt, wenn auf einem interaktiven Element überhaupt kein Tastaturfokus sichtbar ist. 
 Dann ist eventuell auch Prüfschritt
 ifdef::env_embedded[11.2.1.1 "Tastaturbedienung"]
 ifndef::env_embedded[]

--- a/Prüfschritte/de/11.2.4.7 Fokus sichtbar.adoc
+++ b/Prüfschritte/de/11.2.4.7 Fokus sichtbar.adoc
@@ -17,12 +17,9 @@ iOS bietet die Möglichkeit, die Fokushervorhebung durchgängig deutlich darzust
 
 == Warum wird das geprüft?
 
-Für Tastaturbenutzende ist es wichtig, zu sehen, wo sich der Tastaturfokus gerade befindet, 
-welches Bedienelement also ausgelöst wird, wenn es aktiviert wird (z.B. über ENTER oder Leertaste) 
-oder welches Element Ausgangspunkt einer Pfeiltasten-Auswahl wird (etwa bei tab panels oder Auswahllisten).
+Für Tastaturbenutzende ist es wichtig, den aktuellen Tastaturfokus klar zu erkennen – also zu sehen, welches Bedienelement bei Aktivierung (z. B. mit Enter oder der Leertaste) ausgelöst wird oder welches Element als Ausgangspunkt für eine Navigation per Pfeiltasten dient, etwa in Tab-Panels oder Auswahllisten.
 
-Wenn Apps allein durch die Tastatur bedient werden, muss das fokussierte Bedienelement hervorgehoben sein. 
-Eine Tastaturbedienung ist für visuelle Nutzer sonst kaum möglich.
+Wenn eine App ausschließlich per Tastatur bedient wird, muss das fokussierte Bedienelement klar hervorgehoben sein – andernfalls ist die Navigation für visuelle Nutzer kaum möglich.
 
 Die von mobilen Betriebssystemen vorgesehene Standard-Kennzeichnung des Tastaturfokus ist oft nicht gut sichtbar:
 

--- a/Prüfschritte/de/11.2.4.7 Fokus sichtbar.adoc
+++ b/Prüfschritte/de/11.2.4.7 Fokus sichtbar.adoc
@@ -4,14 +4,14 @@ include::include/attributes.adoc[]
 
 == Was wird geprüft?
 
-Werden Bedienelementen mit der Tastatur fokussiert, muss ein sichtbarer Tastaturfokus-Indikator vorhanden sein.
+Werden Bedienelemente mit der Tastatur fokussiert, muss ein sichtbarer Tastaturfokus-Indikator vorhanden sein.
 In diesem Prüfschritt wird lediglich geprüft, ob eine Fokushervorhebung sichtbar ist – nicht, ob sie ausreichend kontrastreich ist. 
 
-Wenn die Fokussierung durch eine vom Entwickler gesteuerte Hervorhebung angezeigt wird, beispielsweise durch eine Farbänderung einer Schaltfläche, 
+Wenn die Fokussierung durch eine vom Entwickler definierte Hervorhebung angezeigt wird, beispielsweise durch die Farbänderung einer Schaltfläche, 
 muss der Kontrast dieser Hervorhebung und der Unterschied zwischen fokussiertem und nicht fokussiertem Zustand mindestens 3:1 betragen.  
 Die Bewertung dieses Kontrasts erfolgt jedoch im Prüfschritt 11.1.4.11 Nicht-Text Kontrast.
 
-Wird die unveränderte Systemfokushervorhebung durchgängig genutzt – meist ein farbiger Rahmen oder eine kontrastarme Einfärbung des Hintergrunds oder des Elements in Hellgrau oder Hellblau – gilt dieser Prüfschritt als erfüllt. Hintergrund ist eine Ausnahme im Erfolgskriterium 1.4.11 (Nicht-Text Kontrast) für native Elemente: "except for inactive components or where the appearance of the component is determined by the user agent and not modified by the author". Bei Apps bezieht sich „user agent“ auf das jeweilige Betriebssystem, also iOS oder Android.
+Wird die unveränderte Systemfokushervorhebung durchgängig genutzt – meist ein farbiger Rahmen oder eine kontrastarme Einfärbung des Hintergrunds oder des Elements in Hellgrau oder Hellblau – gilt dieser Prüfschritt als erfüllt. Hintergrund ist eine Ausnahme im WCAG-Erfolgskriterium 1.4.11 (Nicht-Text Kontrast) für native Elemente: "...except for inactive components or where the appearance of the component is determined by the user agent and not modified by the author". Bei Apps bezieht sich „user agent“ auf das jeweilige Betriebssystem, also iOS oder Android.
 
 iOS bietet die Möglichkeit, die Fokushervorhebung durchgängig deutlich darzustellen (Tastatursteuerung: Hoher Kontrast).
 
@@ -28,8 +28,7 @@ Die von mobilen Betriebssystemen vorgesehene Standard-Kennzeichnung des Tastatur
 * In den iOS-Bedienungshilfen unter "Tastaturen und Texteingabe" > "Tastatursteuerung" kann die Option "Hoher Kontrast" aktiviert werden. Dadurch erhalten alle Elemente mit Tastaturfokus eine gut sichtbare, dicke schwarze Umrandung.
 
 === Android
-* Die Standard-Hervrhebung ist hellgrau auf weiß oder ein leichte Abdunkelung auf Elementen mit egenem farbigen Hintergrund. Das Resultat ist ein sehr geringer Kontrast von etwa 1,2:1.
-
+* Die Tastaturfokus-Hervorhebung ist standardmäßig hellgrau auf weiß oder ein leichte Abdunkelung auf Elementen mit eigenem farbigen Hintergrund. Das Resultat ist ein sehr geringer Kontrast von etwa 1,2:1.
 
 == Wie wird geprüft?
 
@@ -44,9 +43,10 @@ oder Verbindung über Bluetooth-Kopplung oder USB-Kabel anschließen.
 . Zu prüfende Ansicht der App öffnen.
 . Mit der Tabulatortaste zu allen interaktiven Elementen navigieren.
 Wo diese weitere Auswahlen zulassen, etwa bei Tabpanels, Menüs oder Auswahllisten, 
-mit den Pfeiltasten oder ggf. dem Tabulator zu Tabs bzw. Optionen navigieren. Ggf. ist dazu auch die Eingabe von STRG + TAB oder STRG + SHIFT + TAB notwendig.
+mit den Pfeiltasten oder ggf. dem Tabulator zu Tabs bzw. Optionen navigieren. 
+Ggf. ist dazu auch die Eingabe von STRG + TAB oder STRG + SHIFT + TAB notwendig.
 . Prüfen, ob alle Elemente mit grafischen Veränderungen auf den Fokus reagieren 
-(zum Beispiel mit Farbwechseln, Unterstreichungen oder eingeblendeten Symbolen). 
+(zum Beispiel mit Farbwechseln, Rahmen, Unterstreichungen oder eingeblendeten Symbolen). 
 Versteckte Sprunglinks (wo vorhanden) sollen bei Fokuserhalt eingeblendet werden.
 
 === 3. Hinweise
@@ -56,7 +56,7 @@ Der Screenreader-Fokus sollte bei der Beurteilung der Tastaturfokus-Hervorhebung
 
 ==== Erfüllt:
 * Wird nur die native Fokushervorhebung genutzt, ist der Prüfschritt auch erfüllt, wenn die Hervorhebung schwach ist (z.B. hellgraue oder hellblaue Einfärbung), der Kontrast also unter 3:1 liegt.
-* Wird eien vom Entwickler definierte Hervorhebung eingesezt, soll diese einen Kontrast zum Hintergrund von mindestens 3:1 erfüllen. Bewertet wird dies jedoch im Prüfschritt <<11.1.4.11 Nicht-Text-Kontrast.adoc#,11.1.4.11 Nicht-Text Kontrast>>. Wird eine Hervorhebung nur über Änderung der Farbe ungesetzt, ist dies zusätzlich im Prüfschritt <<11.1.4.1 Benutzung von Farbe.adoc#,11.1.4.1 Benutzung von Farbe>> zu prüfen und zu bewerten.
+* Wird eine vom Entwickler definierte Hervorhebung eingesezt, soll diese einen Kontrast zum Hintergrund von mindestens 3:1 erfüllen. Bewertet wird dies jedoch im Prüfschritt <<11.1.4.11 Nicht-Text-Kontrast.adoc#,11.1.4.11 Nicht-Text Kontrast>>. Wird eine Hervorhebung nur über Änderung der Farbe ungesetzt, ist dies zusätzlich im Prüfschritt <<11.1.4.1 Benutzung von Farbe.adoc#,11.1.4.1 Benutzung von Farbe>> zu prüfen und zu bewerten.
 
 ==== Nicht erfüllt
 * Der Prüfschritt ist nicht erfüllt, wenn auf einem interaktiven Element überhaupt kein Tastaturfokus sichtbar ist. 

--- a/Prüfschritte/de/11.2.4.7 Fokus sichtbar.adoc
+++ b/Prüfschritte/de/11.2.4.7 Fokus sichtbar.adoc
@@ -5,7 +5,7 @@ include::include/attributes.adoc[]
 == Was wird geprüft?
 
 Werden Bedienelementen mit der Tastatur fokussiert, dann soll es einen sichtbaren Tastaturfokus-Indikator geben.
-Es wird also in diesem Prüfschritt  nur geprüft, ob überhaupt eine Tastatur-Fokushervorhebung sichtbar ist - nicht, ob diese ausreichend kontrastreich ist. 
+Es wird also in diesem Prüfschritt  nur geprüft, ob überhaupt eine Tastatur-Fokushervorhebung sichtbar ist - nicht, ob dieser ausreichend kontrastreich ist. 
 
 Wenn Fokussierung durch eine Entwickler-gesteuerte Hervorhebung, z.B. die Änderung der Farbe einer Schaltfläche bei Fokussierung, angezeigt wird, 
 soll der Kontrast der Hervorhebung und der Kontrastunterschied zwischen fokussiertem und nicht fokussiertem Zustand mindestens 3:1 betragen. 

--- a/Prüfschritte/de/11.2.4.7 Fokus sichtbar.adoc
+++ b/Prüfschritte/de/11.2.4.7 Fokus sichtbar.adoc
@@ -50,7 +50,7 @@ mit den Pfeiltasten oder ggf. dem Tabulator zu Tabs bzw. Optionen navigieren. Gg
 Versteckte Sprunglinks (wo vorhanden) sollen bei Fokuserhalt eingeblendet werden.
 
 === 3. Hinweise
-Der Screenreader-Fokus sollte bei der Beurteilung der Tastaturfokus-Hervorhebung nicht berücksichtigt werden. Die Prüfung erfolgt mit verbundener Tastatur und ausgeschaltetem Screenreader.
+Der Screenreader-Fokus sollte bei der Beurteilung der Tastaturfokus-Hervorhebung nicht berücksichtigt werden. Die Prüfung erfolgt mit angeschlossener Tastatur und ausgeschaltetem Screenreader.
 
 === 4. Bewertung
 

--- a/Prüfschritte/de/11.2.4.7 Fokus sichtbar.adoc
+++ b/Prüfschritte/de/11.2.4.7 Fokus sichtbar.adoc
@@ -4,16 +4,16 @@ include::include/attributes.adoc[]
 
 == Was wird geprüft?
 
-Werden Bedienelementen mit der Tastatur fokussiert, dann soll es einen sichtbaren Tastaturfokus-Indikator geben.
-Es wird also in diesem Prüfschritt  nur geprüft, ob überhaupt eine Tastatur-Fokushervorhebung sichtbar ist - nicht, ob dieser ausreichend kontrastreich ist. 
+Werden Bedienelementen mit der Tastatur fokussiert, muss ein sichtbarer Tastaturfokus-Indikator vorhanden sein.
+In diesem Prüfschritt wird lediglich geprüft, ob eine Fokushervorhebung sichtbar ist – nicht, ob sie ausreichend kontrastreich ist. 
 
-Wenn Fokussierung durch eine Entwickler-gesteuerte Hervorhebung, z.B. die Änderung der Farbe einer Schaltfläche bei Fokussierung, angezeigt wird, 
-soll der Kontrast der Hervorhebung und der Kontrastunterschied zwischen fokussiertem und nicht fokussiertem Zustand mindestens 3:1 betragen. 
-Dies wird jedoch im Prüfschritt 11.1.4.11 Nicht-Text Kontrast bewertet.
+Wenn die Fokussierung durch eine vom Entwickler gesteuerte Hervorhebung angezeigt wird, beispielsweise durch eine Farbänderung einer Schaltfläche, 
+muss der Kontrast dieser Hervorhebung und der Unterschied zwischen fokussiertem und nicht fokussiertem Zustand mindestens 3:1 betragen.  
+Die Bewertung dieses Kontrasts erfolgt jedoch im Prüfschritt 11.1.4.11 Nicht-Text Kontrast.
 
-Wird eine unveränderte Systemfokushervorhebung durchgängig genutzt (meist eine farbiger Rahmen oder hellgraue oder hellblaue kontrastarme Einfärbung des Hintergrunds oder des Elements), gilt dieser Prüfschritt als erfüllt, denn bezüglich Kontrast gibt es eine Ausnahme im Erfolgskriterium 1.4.11 (Nicht-Text Kontrast) für native Elemente: "except for inactive components or where the appearance of the component is determined by the user agent and not modified by the author". Für Apps ist statt "user agent" das Betriebssystem (iOS oder Android) die zuständige Plattform.
+Wird die unveränderte Systemfokushervorhebung durchgängig genutzt – meist ein farbiger Rahmen oder eine kontrastarme Einfärbung des Hintergrunds oder des Elements in Hellgrau oder Hellblau – gilt dieser Prüfschritt als erfüllt. Hintergrund ist eine Ausnahme im Erfolgskriterium 1.4.11 (Nicht-Text Kontrast) für native Elemente: "except for inactive components or where the appearance of the component is determined by the user agent and not modified by the author". Bei Apps bezieht sich „user agent“ auf das jeweilige Betriebssystem, also iOS oder Android.
 
-iOS bietet die Möglichkeit, die Fokushervorhebung durchgängig deutlich darzustellen ( Tastatursteuerung: Hoher Kontrast).
+iOS bietet die Möglichkeit, die Fokushervorhebung durchgängig deutlich darzustellen (Tastatursteuerung: Hoher Kontrast).
 
 == Warum wird das geprüft?
 

--- a/Prüfschritte/de/11.2.4.7 Fokus sichtbar.adoc
+++ b/Prüfschritte/de/11.2.4.7 Fokus sichtbar.adoc
@@ -29,7 +29,9 @@ Die von mobilen Betriebssystemen vorgesehene Kennzeichnung des Tastaturfokus ist
 
 * iOS: Die Standard-Hervorhebung von über Tabulator erreichbaren Bereichen ist recht gut (deutlicher blauer Rahmen),
 bei über Pfeiltasten erreichbaren Einträgen innerhalb fokussierter Bereiche ist die Hervorhebung aber schlecht:
-hellblau auf weiß mit einem sehr geringen Kontrast von nur 1,2:1. In den Bedienungshilfen-Einstellungen von iOS lässt sich jedoch unter "Tastaturen und Texteingabe" > "Tastatursteuerung" die Option "Hoher Kontrast" einstellen. Damit werden alle Elemente, die überhaupt den Tastaturfokus bekommen, sehr deulich über dicke schwarze Umrandung hervorgehoben. 
+hellblau auf weiß mit einem sehr geringen Kontrast von nur 1,2:1. 
+In den Bedienungshilfen-Einstellungen von iOS lässt sich jedoch unter "Tastaturen und Texteingabe" > "Tastatursteuerung" die Option "Hoher Kontrast" einstellen. 
+Damit werden alle Elemente, die überhaupt den Tastaturfokus bekommen, sehr deulich über dicke schwarze Umrandung hervorgehoben. 
 
 * Android: Die Standard-Hervrhebung ist hellgrau auf weiß  mit einem sehr geringen Kontrast von nur 1,2:1.
 

--- a/Prüfschritte/de/11.2.4.7 Fokus sichtbar.adoc
+++ b/Prüfschritte/de/11.2.4.7 Fokus sichtbar.adoc
@@ -56,9 +56,7 @@ Versteckte Sprunglinks sollen bei Fokuserhalt eingeblendet werden.
 
 === 3. Hinweise
 ==== 3.1 Allgemeine Hinweise
-* Falls das Betriebssystem Einstellungen zur verbesserten Sichtbarkeit der Fokushervorhebung bietet,
-sollten diese deaktiviert sein, denn viele Nutzende kennen diese Einstellungen nicht.
-
+* Es kann davon ausgegangen werden, dass sehbehinderte Tastaturnutzende betriebssystemseitige Einstellungen zu verbesserten Darstellung des Tastaturfokus (wo vorhanden)  nutzen, wenn die Standardhervorhebung für sie nicht ausreichend ist. In iOS wird die Option "Hoher Kontrast" an der gleichen Stelle geboten, wo überhaupt die Tastatursteurung aktiviert wird.
 * Der Prüfschritt ist nicht erfüllt, wenn überhaupt kein Tastaturfokus sichtbar ist.
 Dann ist eventuell auch Prüfschritt
 ifdef::env_embedded[11.2.1.1 "Tastaturbedienung"]


### PR DESCRIPTION
* Die native Fokushervorhebung (auch wenn sie nicht kontrastreich genug ist) erfüllt diesen Prüfschritt jetzt.
* Entwicker-definierte Hervorhebungen (z.B. Farbwechsel) müssen mindestens einen 3:1 Kontrast haben (bewertet wird dies in aber in Prüfschritt 11.1.4.11 Nicht-Text Kontrast)
* Ergänzung des Hinweises, dass iOS in den Bedienungshilfen unter Tastatursteuerung die Option "Hoher Kontrast" bietet, welche eine durchgehend gute Hervorhebung auf Systemseite sicherstellt.
